### PR TITLE
Small change to format argument and ability to override defaultExtension.

### DIFF
--- a/src/Knplabs/Snappy/Image.php
+++ b/src/Knplabs/Snappy/Image.php
@@ -27,7 +27,7 @@ class Image extends Media
         'debug-javascript' => null,               // Show javascript debugging output
         'no-debug-javascript' => null,            // Do not show javascript debugging output (default)
         'encoding' => null,                       // Set the default text encoding, for input
-        'f' => null,                              // Output format
+        'format' => null,                         // Output format
         'images' => null,                         // Do load or print images (default)
         'no-images' => null,                      // Do not load or print images 
         'disable-javascript' => null,             // Do not allow web pages to run javascript

--- a/src/Knplabs/Snappy/Media.php
+++ b/src/Knplabs/Snappy/Media.php
@@ -10,7 +10,8 @@ abstract class Media
     protected $executable;
     protected $options = array();
     protected $defaultExtension;
-    
+    protected $extension;
+
     const URL_PATTERN = '~^
             (http|https|ftp)://                                 # protocol
             (
@@ -28,8 +29,15 @@ abstract class Media
      * @param string $executable 
      * @param array $options 
      */
-    function __construct($executable, array $options = array())
+    function __construct($executable, array $options = array(), $ext = null)
     {
+	if ($ext != null) {
+		$this->extension = $ext;
+	}
+	else {
+		$this->extension = $defaultExtension;
+	}
+
         $this->setExecutable($executable);
         $this->mergeOptions($options);
     }
@@ -42,7 +50,7 @@ abstract class Media
      */
     public function output($url)
     {
-        $file = tempnam(sys_get_temp_dir(), 'knplabs_snappy') . '.' . $this->defaultExtension;
+        $file = tempnam(sys_get_temp_dir(), 'knplabs_snappy') . '.' . $this->extension;
 
         $ok = $this->save($url, $file);
         $content = null;
@@ -58,7 +66,7 @@ abstract class Media
      */
     public function get($url)
     {
-        $file = tempnam(sys_get_temp_dir(), 'knplabs_snappy') . '.' . $this->defaultExtension;
+        $file = tempnam(sys_get_temp_dir(), 'knplabs_snappy') . '.' . $this->extension;
 
         $ok = $this->save($url, $file);
         $content = null;


### PR DESCRIPTION
Replaced 'f' argument with full 'format' long version since all commands are prepended with '--'.

Since there was no way of overriding the defaultExtension, changed the constructor so an extension to use
may be passed in (optional).
