### PR TITLE
[Image] Fix the default image format to 'jpg'. 

### DIFF
--- a/src/Knp/Snappy/Image.php
+++ b/src/Knp/Snappy/Image.php
@@ -45,7 +45,7 @@ class Image extends Media
             'debug-javascript'             => null,    // Show javascript debugging output
             'no-debug-javascript'          => null,    // Do not show javascript debugging output (default)
             'encoding'                     => null,    // Set the default text encoding, for input
-            'f'                            => null,    // Output format
+            'format'                       => 'jpg',   // Output format
             'images'                       => null,    // Do load or print images (default)
             'no-images'                    => null,    // Do not load or print images
             'disable-javascript'           => null,    // Do not allow web pages to run javascript


### PR DESCRIPTION
- Use the full option name; otherwise the command is --f
- On Mac, the default format is not working. You need to set the --format option or use a valid filename extension.
