### PR TITLE
Hacky fix to allow --custom-header to work

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -314,12 +314,16 @@ abstract class AbstractGenerator implements GeneratorInterface
             if (null !== $value && false !== $value) {
                 if (true === $value) {
                     $command .= " --".$key;
-                } elseif (is_array($value)) {
+                } elseif (is_array($value) and !empty($value)) {
+                    $command .= " --".$key;
                     foreach ($value as $v) {
-                        $command .= " --".$key." ".escapeshellarg($v);
+                        $command .= " ".escapeshellarg($v);
                     }
                 } else {
-                    $command .= " --".$key." ".escapeshellarg($value);
+                    $command .= " --".$key;
+                    if (!empty($value) {
+                        $command.=" ".escapeshellarg($value);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Changes buildCommand() slightly so that --cookie, --custom-header, --post, and --post-file can pass their multiple arguments to the command.
