### PR TITLE
Add support for key-multivalues for options - fix #18

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -338,12 +338,13 @@ abstract class AbstractGenerator implements GeneratorInterface
             if (null !== $value && false !== $value) {
                 if (true === $value) {
                     $command .= " --".$key;
-                } elseif (is_array($value)) {
-                    foreach ($value as $v) {
-                        $command .= " --".$key." ".escapeshellarg($v);
-                    }
-                } else {
-                    $command .= " --".$key." ".escapeshellarg($value);
+                    continue;
+                }
+                if (!is_array($value)) {
+                    $value = array($value);
+                }
+                foreach ($value as $v) {
+                    $command .= " --".$key." ".str_replace(" ", "' '", escapeshellarg($v));
                 }
             }
         }

--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -422,6 +422,16 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 ),
                 'thebinary --foo \'foovalue\' --bar \'barvalue1\' --bar \'barvalue2\' --baz "http://the.url/" "/the/path"'
             ),
+            array(
+                'thebinary',
+                'http://the.url/',
+                '/the/path',
+                array(
+                    'bar'   => array('tip tap', 'top'),
+                    'quz'   => 'hip hop',
+                ),
+                'thebinary --bar \'tip\' \'tap\' --bar \'top\' --quz \'hip\' \'hop\' "http://the.url/" "/the/path"'
+            ),
         );
     }
 


### PR DESCRIPTION
Fix #18

To specify a key-value option :

```
$snappy->setOption('cookie', 'cookie_name value');
```
