### PR TITLE
Use associative array for key-value options

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -338,12 +338,17 @@ abstract class AbstractGenerator implements GeneratorInterface
             if (null !== $value && false !== $value) {
                 if (true === $value) {
                     $command .= " --".$key;
-                } elseif (is_array($value)) {
-                    foreach ($value as $v) {
-                        $command .= " --".$key." ".escapeshellarg($v);
+                    continue;
+                }
+                if (!is_array($value)) {
+                    $value = array($value);
+                }
+                foreach ($value as $k => $v) {
+                    $command .= " --".$key;
+                    if (!is_int($k)) {
+                    	$command .= " ".escapeshellarg($k);
                     }
-                } else {
-                    $command .= " --".$key." ".escapeshellarg($value);
+                    $command .= " ".escapeshellarg($v);
                 }
             }
         }

--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -422,6 +422,16 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 ),
                 'thebinary --foo \'foovalue\' --bar \'barvalue1\' --bar \'barvalue2\' --baz "http://the.url/" "/the/path"'
             ),
+            array(
+                'thebinary',
+                'http://the.url/',
+                '/the/path',
+                array(
+                    'foo'   => array('name' => 'foovalue'),
+                    'bar'   => array('A' => 'barvalue1', 'B' => 'barvalue2'),
+                ),
+                'thebinary --foo \'name\' \'foovalue\' --bar \'A\' \'barvalue1\' --bar \'B\' \'barvalue2\' "http://the.url/" "/the/path"'
+            ),
         );
     }
 


### PR DESCRIPTION
Fix #18

Use an associative array to set key-value options.
