### PR TITLE
Add support of Symfony/Process component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,10 @@
         "php": ">=5.3.0"
     },
 
+    "suggest": {
+        "symfony/process": "Process Component of Symfony2."
+    },
+
     "autoload": {
         "psr-0": {
             "Knp\\Snappy": "src/"

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -384,32 +384,19 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     protected function executeCommand($command)
     {
-        $stdout = $stderr = $status = null;
-        $descriptorspec = array(
-           1 => array('pipe', 'w'),  // stdout is a pipe that the child will write to
-           2 => array('pipe', 'a') // stderr is a pipe that the child will append to
-        );
-
-        $process = proc_open($command, $descriptorspec, $pipes);
-
-        if (is_resource($process)) {
-            // $pipes now looks like this:
-            // 0 => writeable handle connected to child stdin
-            // 1 => readable handle connected to child stdout
-            // 2 => readable handle connected to child stderr
-
-            $stdout = stream_get_contents($pipes[1]);
-            fclose($pipes[1]);
-
-            $stderr = stream_get_contents($pipes[2]);
-            fclose($pipes[2]);
-
-            // It is important that you close any pipes before calling
-            // proc_close in order to avoid a deadlock
-            $status = proc_close($process);
+        if (class_exists('Symfony\Component\Process\Process')) {
+            $process = new \Symfony\Component\Process\Process($command);
+        } else {
+            $process = new Process($command);
         }
 
-        return array($status, $stdout, $stderr);
+        $process->run();
+
+        return array(
+            $process->getExitCode(),
+            $process->getOutput(),
+            $process->getErrorOutput(),
+        );
     }
 
     /**

--- a/src/Knp/Snappy/Process.php
+++ b/src/Knp/Snappy/Process.php
@@ -1,0 +1,96 @@
+<?php
+namespace Knp\Snappy;
+
+/**
+ * Process a command, this class is a fallback if user has not
+ * symfony component process
+ *
+ * @package Snappy
+ *
+ * @author  Matthieu Bontemps <matthieu.bontemps@knplabs.com>
+ * @author  Antoine Hérault <antoine.herault@knplabs.com>
+ */
+class Process
+{
+    /**
+     * @var string
+     */
+    private $command;
+
+    /**
+     * @var integer
+     */
+    private $exitCode;
+
+    /**
+     * @var string
+     */
+    private $errorOutput;
+
+    /**
+     * @var string
+     */
+    private $output;
+
+    /**
+     * @param string $command command
+     */
+    public function __construct($command)
+    {
+        $this->command = $command;
+    }
+
+    /**
+     * run the command defined on the constructor
+     */
+    public function run()
+    {
+        $descriptorspec = array(
+            1 => array('pipe', 'w'),  // stdout is a pipe that the child will write to
+            2 => array('pipe', 'a') // stderr is a pipe that the child will append to
+        );
+
+        $process = proc_open($this->command, $descriptorspec, $pipes);
+
+        if (is_resource($process)) {
+            // $pipes now looks like this:
+            // 0 => writeable handle connected to child stdin
+            // 1 => readable handle connected to child stdout
+            // 2 => readable handle connected to child stderr
+
+            $this->output = stream_get_contents($pipes[1]);
+            fclose($pipes[1]);
+
+            $this->errorOutput = stream_get_contents($pipes[2]);
+            fclose($pipes[2]);
+
+            // It is important that you close any pipes before calling
+            // proc_close in order to avoid a deadlock
+            $this->exitCode = proc_close($process);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorOutput()
+    {
+        return $this->errorOutput;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOutput()
+    {
+        return $this->output;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getExitCode()
+    {
+        return $this->exitCode;
+    }
+}


### PR DESCRIPTION
Hi, i added the support of `Symfony/Process` component, it exists a stub if `process` component is not installed, the behavior btw not change, just support the `process` component.

I added a suggest section on composer too
