### PR TITLE
Modify proc_open for Windows

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -390,7 +390,8 @@ abstract class AbstractGenerator implements GeneratorInterface
            2 => array('pipe', 'a') // stderr is a pipe that the child will append to
         );
 
-        $process = proc_open($command, $descriptorspec, $pipes);
+        $other_options = array('bypass_shell' => true);
+        $process = proc_open($command, $descriptorspec, $pipes, NULL, NULL, $other_options);
 
         if (is_resource($process)) {
             // $pipes now looks like this:


### PR DESCRIPTION
I had to make this change to get snappy working on a windows server (as otherwise the web server has to have privileges to run cmd.exe). Might be a good idea to merge it into master.
