### PR TITLE
Escaped also the binary path, so special chars or simply spaces can occur in the path or name.

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -334,7 +334,7 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     protected function buildCommand($binary, $input, $output, array $options = array())
     {
-        $command = $binary;
+        $command = escapeshellarg($binary);
 
         foreach ($options as $key => $option) {
             if (null !== $option && false !== $option) {

--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -398,7 +398,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 'http://the.url/',
                 '/the/path',
                 array(),
-                "thebinary 'http://the.url/' '/the/path'"
+                "'thebinary' 'http://the.url/' '/the/path'"
             ),
             array(
                 'thebinary',
@@ -409,7 +409,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                     'bar'   => false,
                     'baz'   => array()
                 ),
-                "thebinary 'http://the.url/' '/the/path'"
+                "'thebinary' 'http://the.url/' '/the/path'"
             ),
             array(
                 'thebinary',
@@ -420,7 +420,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                     'bar'   => array('barvalue1', 'barvalue2'),
                     'baz'   => true
                 ),
-                "thebinary --foo 'foovalue' --bar 'barvalue1' --bar 'barvalue2' --baz 'http://the.url/' '/the/path'"
+                "'thebinary' --foo 'foovalue' --bar 'barvalue1' --bar 'barvalue2' --baz 'http://the.url/' '/the/path'"
             ),
             array(
                 'thebinary',
@@ -430,7 +430,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                     'cookie'   => array('session' => 'bla', 'phpsess' => 12),
                     'no-background'   => '1',
                 ),
-                "thebinary --cookie 'session' 'bla' --cookie 'phpsess' '12' --no-background '1' 'http://the.url/' '/the/path'"
+                "'thebinary' --cookie 'session' 'bla' --cookie 'phpsess' '12' --no-background '1' 'http://the.url/' '/the/path'"
             ),
             array(
                 'thebinary',
@@ -440,7 +440,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                     'allow'   => array('/path1', '/path2'),
                     'no-background'   => '1',
                 ),
-                "thebinary --allow '/path1' --allow '/path2' --no-background '1' 'http://the.url/' '/the/path'"
+                "'thebinary' --allow '/path1' --allow '/path2' --no-background '1' 'http://the.url/' '/the/path'"
             ),
         );
     }


### PR DESCRIPTION
Ran into this bug (?) today. Is there anything speaking against this solution?
