### PR TITLE
escape binary path only if it's executable

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -334,7 +334,11 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     protected function buildCommand($binary, $input, $output, array $options = array())
     {
-        $command = escapeshellarg($binary);
+        $command = $binary;
+        $escapedBinary = escapeshellarg($binary);
+        if (is_executable($escapedBinary)) {
+            $command = $escapedBinary;
+        }
 
         foreach ($options as $key => $option) {
             if (null !== $option && false !== $option) {

--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -390,18 +390,45 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $r->invokeArgs($media, array($binary, $url, $path, $options)));
     }
 
+    private function getPHPExecutableFromPath() {
+        if (isset($_SERVER["_"])) {
+            return $_SERVER["_"];
+        }
+
+        if (@defined(PHP_BINARY)) {
+            return PHP_BINARY;
+        }
+
+        $paths = explode(PATH_SEPARATOR, getenv('PATH'));
+        foreach ($paths as $path) {
+            // we need this for XAMPP (Windows)
+            if (strstr($path, 'php.exe') && isset($_SERVER["WINDIR"]) && file_exists($path) && is_file($path)) {
+                return $path;
+            }
+            else {
+                $php_executable = $path . DIRECTORY_SEPARATOR . "php" . (isset($_SERVER["WINDIR"]) ? ".exe" : "");
+                if (file_exists($php_executable) && is_file($php_executable)) {
+                    return $php_executable;
+                }
+            }
+        }
+        return FALSE; // not found
+    }
+
     public function dataForBuildCommand()
     {
+        $theBinary = $this->getPHPExecutableFromPath() . ' -v'; // i.e.: '/usr/bin/php -v'
+
         return array(
             array(
-                'thebinary',
+                $theBinary,
                 'http://the.url/',
                 '/the/path',
                 array(),
-                "'thebinary' 'http://the.url/' '/the/path'"
+                "{$theBinary} 'http://the.url/' '/the/path'"
             ),
             array(
-                'thebinary',
+                $theBinary,
                 'http://the.url/',
                 '/the/path',
                 array(
@@ -409,10 +436,10 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                     'bar'   => false,
                     'baz'   => array()
                 ),
-                "'thebinary' 'http://the.url/' '/the/path'"
+                "{$theBinary} 'http://the.url/' '/the/path'"
             ),
             array(
-                'thebinary',
+                $theBinary,
                 'http://the.url/',
                 '/the/path',
                 array(
@@ -420,27 +447,27 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                     'bar'   => array('barvalue1', 'barvalue2'),
                     'baz'   => true
                 ),
-                "'thebinary' --foo 'foovalue' --bar 'barvalue1' --bar 'barvalue2' --baz 'http://the.url/' '/the/path'"
+                "{$theBinary} --foo 'foovalue' --bar 'barvalue1' --bar 'barvalue2' --baz 'http://the.url/' '/the/path'"
             ),
             array(
-                'thebinary',
+                $theBinary,
                 'http://the.url/',
                 '/the/path',
                 array(
                     'cookie'   => array('session' => 'bla', 'phpsess' => 12),
                     'no-background'   => '1',
                 ),
-                "'thebinary' --cookie 'session' 'bla' --cookie 'phpsess' '12' --no-background '1' 'http://the.url/' '/the/path'"
+                "{$theBinary} --cookie 'session' 'bla' --cookie 'phpsess' '12' --no-background '1' 'http://the.url/' '/the/path'"
             ),
             array(
-                'thebinary',
+                $theBinary,
                 'http://the.url/',
                 '/the/path',
                 array(
                     'allow'   => array('/path1', '/path2'),
                     'no-background'   => '1',
                 ),
-                "'thebinary' --allow '/path1' --allow '/path2' --no-background '1' 'http://the.url/' '/the/path'"
+                "{$theBinary} --allow '/path1' --allow '/path2' --no-background '1' 'http://the.url/' '/the/path'"
             ),
         );
     }


### PR DESCRIPTION
Fixes the issue came up in #66

Many people use special bin paths such as:
- `export DISPLAY=:0;/bin/wkhtmltopdf`
- `/usr/bin/xvfb-run -a -s "-screen 0 640x480x16" /opt/wkhtmltopdf/wkhtmltopdf --quiet`

These paths must not be escaped.
In this pull request, the escaped command is used only if the escaped string is executable.
