### PR TITLE
fixing Process call to Symfony to be 2.0 compatible

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -412,7 +412,7 @@ abstract class AbstractGenerator implements GeneratorInterface
     protected function executeCommand($command)
     {
         if (class_exists('Symfony\Component\Process\Process')) {
-            $process = new \Symfony\Component\Process\Process($command, $this->env);
+            $process = new \Symfony\Component\Process\Process($command, NULL, $this->env);
             if ($this->timeout !== false) {
                 $process->setTimeout($this->timeout);
             }


### PR DESCRIPTION
The Process constructor of Symfony expects the second parameter to be string or NULL (the current working directory)
