### PR TITLE
Update website link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@ Snappy is a PHP5 library allowing thumbnail, snapshot or PDF generation from a u
 It uses the excellent webkit-based [wkhtmltopdf and wkhtmltoimage](http://wkhtmltopdf.org/)
 available on OSX, linux, windows.
 
-You will have to download wkhtmltopdf `0.11.0 >= rc1` in order to use Snappy.
+You will have to download wkhtmltopdf `0.12.0` in order to use Snappy.
 
 [![Build Status](https://secure.travis-ci.org/KnpLabs/snappy.png?branch=master)](http://travis-ci.org/KnpLabs/snappy)
 


### PR DESCRIPTION
Probably could have done this with the previos change in readme..
But the old website just says 'Now hosted at http://wkhtmltopdf.org'
