### PR TITLE
dont't add  '--' before cover and toc options when buildCommand is calle...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,6 +60,8 @@ $snappy->setOption('disable-javascript', true);
 $snappy->setOption('no-background', true);
 $snappy->setOption('allow', array('/path1', '/path2'));
 $snappy->setOption('cookie', array('key' => 'value', 'key2' => 'value2'));
+$snappy->setOption('cover', 'pathToCover.html');
+$snappy->setOption('toc', true);
 ```
 
 ## wkhtmltopdf binary as composer dependencies

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -372,7 +372,12 @@ abstract class AbstractGenerator implements GeneratorInterface
             if (null !== $option && false !== $option) {
 
                 if (true === $option) {
-                    $command .= ' --'.$key;
+                    // Dont't put '--' if option is 'toc'.
+                    if ($key == 'toc') {
+                        $command .= ' '.$key;
+                    } else {
+                        $command .= ' --'.$key;
+                    }
 
                 } elseif (is_array($option)) {
                     if ($this->isAssociativeArray($option)) {
@@ -381,12 +386,17 @@ abstract class AbstractGenerator implements GeneratorInterface
                         }
                     } else {
                         foreach ($option as $v) {
-                            $command .= " --".$key." ".escapeshellarg($v);
+                            $command .= ' --'.$key.' '.escapeshellarg($v);
                         }
                     }
 
                 } else {
-                    $command .= ' --'.$key." ".escapeshellarg($option);
+                    // Dont't add '--' if option is "cover"  or "toc".
+                    if (in_array($key, array('toc', 'cover'))) {
+                        $command .= ' '.$key;
+                    } else {
+                        $command .= ' --'.$key.' '.escapeshellarg($option);
+                    }
                 }
             }
         }


### PR DESCRIPTION
`toc` and `cover` option dont' need `--`before them when buildCommand is called..

See issue #43 : How to use cover & toc options
