### PR TITLE
Add a possibility to specify the temporary folder

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -21,6 +21,11 @@ abstract class AbstractGenerator implements GeneratorInterface
     private $defaultExtension;
 
     /**
+     * @var string
+     */
+    protected $temporaryFolder;
+
+    /**
      * Constructor
      *
      * @param string $binary
@@ -346,7 +351,8 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     protected function createTemporaryFile($content = null, $extension = null)
     {
-        $filename = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . uniqid('knp_snappy', true);
+        $filename = rtrim($this->getTemporaryFolder(), DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR . uniqid('knp_snappy', true);
 
         if (null !== $extension) {
             $filename .= '.'.$extension;
@@ -501,6 +507,34 @@ abstract class AbstractGenerator implements GeneratorInterface
                 $directory
             ));
         }
+    }
+
+    /**
+     * Get TemporaryFolder
+     *
+     * @return string
+     */
+    public function getTemporaryFolder()
+    {
+        if ($this->temporaryFolder === null) {
+            return sys_get_temp_dir();
+        }
+
+        return $this->temporaryFolder;
+    }
+
+    /**
+     * Set temporaryFolder
+     *
+     * @param string $temporaryFolder
+     *
+     * @return $this
+     */
+    public function setTemporaryFolder($temporaryFolder)
+    {
+        $this->temporaryFolder = $temporaryFolder;
+
+        return $this;
     }
 
     /**

--- a/test/Knp/Snappy/PdfTest.php
+++ b/test/Knp/Snappy/PdfTest.php
@@ -20,6 +20,27 @@ class PdfTest extends \PHPUnit_Framework_TestCase
         $testObject->getOutputFromHtml('<html></html>', array());
         $this->assertRegExp("/emptyBinary --lowquality '.*' '.*'/", $testObject->getLastCommand());
     }
+
+    public function testThatSomethingUsingTmpFolder()
+    {
+        $testObject = new PdfSpy();
+        $testObject->setTemporaryFolder(__DIR__);
+
+        $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer'));
+        $this->assertRegExp("/emptyBinary --lowquality --footer-html '.*' '.*' '.*'/", $testObject->getLastCommand());
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     */
+    public function testThatSomethingUsingWrongTmpFolder()
+    {
+        $testObject = new PdfSpy();
+        $testObject->setTemporaryFolder(__DIR__.'/i-dont-exist');
+
+        $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer'));
+    }
+
 }
 
 class PdfSpy extends Pdf


### PR DESCRIPTION
This pull-request adds a new feature for use your own temporary folder. In my project, i can't use "/tmp" return by "sys_get_temp_dir()"  and i can't change this folder because i'm on PHP 5.4
