### PR TITLE
remove only temporary files created by the generator, on destruct

### DIFF
--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -25,7 +25,7 @@ class Pdf extends AbstractGenerator
     /**
      * handle options to transform HTML header-html or footer-html into files contains HTML
      * @param array $options
-     * @return array $options Tranformed options
+     * @return array $options Transformed options
      */
     protected function handleOptions(array $options = array())
     {
@@ -48,15 +48,6 @@ class Pdf extends AbstractGenerator
         $options = $this->handleOptions($options);
 
         parent::generate($input, $output, $options, $overwrite);
-
-        // to delete header or footer generated files
-        if ($this->isFileHeader($options) && $this->isFile($options['header-html'])) {
-            $this->unlink($options['header-html']);
-        }
-
-        if ($this->isFileFooter($options) && $this->isFile($options['footer-html'])) {
-            $this->unlink($options['footer-html']);
-        }
     }
 
     /**

--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -194,7 +194,6 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 'configure',
                 'generate',
                 'createTemporaryFile',
-                'unlink'
             ),
             array(
                 'the_binary'
@@ -210,12 +209,6 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo('html')
             )
             ->will($this->returnValue('the_temporary_file'))
-        ;
-        $media
-            ->expects($this->once())
-            ->method('unlink')
-            ->with($this->equalTo('the_temporary_file'))
-            ->will($this->returnValue(true))
         ;
         $media
             ->expects($this->once())
@@ -238,7 +231,6 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 'configure',
                 'generate',
                 'createTemporaryFile',
-                'unlink'
             ),
             array(
                 'the_binary'
@@ -254,12 +246,6 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo('html')
             )
             ->will($this->returnValue('the_temporary_file'))
-        ;
-        $media
-            ->expects($this->once())
-            ->method('unlink')
-            ->with($this->equalTo('the_temporary_file'))
-            ->will($this->returnValue(true))
         ;
         $media
             ->expects($this->once())
@@ -337,7 +323,6 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 'configure',
                 'getOutput',
                 'createTemporaryFile',
-                'unlink'
             ),
             array(),
             '',
@@ -360,12 +345,6 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo(array('foo' => 'bar'))
             )
             ->will($this->returnValue('the output'))
-        ;
-        $media
-            ->expects($this->once())
-            ->method('unlink')
-            ->with($this->equalTo('the_temporary_file'))
-            ->will($this->returnValue(true))
         ;
 
         $this->assertEquals('the output', $media->getOutputFromHtml('<html>foo</html>', array('foo' => 'bar')));
@@ -379,7 +358,6 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 'configure',
                 'getOutput',
                 'createTemporaryFile',
-                'unlink'
             ),
             array(),
             '',
@@ -402,12 +380,6 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo(array('foo' => 'bar'))
             )
             ->will($this->returnValue('the output'))
-        ;
-        $media
-            ->expects($this->once())
-            ->method('unlink')
-            ->with($this->equalTo('the_temporary_file'))
-            ->will($this->returnValue(true))
         ;
 
         $this->assertEquals('the output', $media->getOutputFromHtml(array('<html>foo</html>'), array('foo' => 'bar')));


### PR DESCRIPTION
My basic problem was, that I wanted to include static html files into the header and the footer, and this lib. tried to remove them, but of course it must not do that.

This PR fixes this problem:
- only the temporary files created by the lib. will be deleted
- unit tests had to be modified as the destructor cannot be mocked
- also fixes #122 
