### PR TITLE
Making binary path system agnostic.

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -207,7 +207,7 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     public function setBinary($binary)
     {
-        $this->binary = $binary;
+        $this->binary = realpath($binary);
     }
 
     /**


### PR DESCRIPTION
Using realpath allows to $binary to be a path mixed - as an example - with windows and unix syntax; as PHP will arrange it to be in the syntax of the current system.

If used with KnpSnappyBundle and h4cc/wkhtmltopdf-amd64 in Symfony2, it will allow to configure the binary path as: 

    knp_snappy:
        pdf:
            binary:     "%kernel.root_dir%/../vendor/h4cc/wkhtmltopdf-amd64/bin/wkhtmltopdf-amd64"

And this will work in both Windows and Unix systems, as PHP will translate that path to the right syntax.