### PR TITLE
fixed that passing an empty array as env argument would clean default environment variables within the forked process

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -43,7 +43,7 @@ abstract class AbstractGenerator implements GeneratorInterface
 
         $this->setBinary($binary);
         $this->setOptions($options);
-        $this->env = $env;
+        $this->env = empty($env) ? null : $env;
     }
 
     public function __destruct()
@@ -361,7 +361,7 @@ abstract class AbstractGenerator implements GeneratorInterface
         if (null !== $content) {
             file_put_contents($filename, $content);
         }
-        
+
         $this->temporaryFiles[] = $filename;
 
         return $filename;


### PR DESCRIPTION
Just a quick and dirty approach to fix an issue introduced with #131, see KnpLabs/KnpSnappyBundle#83. Let me know if there's a cleaner solution.

/cc @TheBeakerMan, @plakjeworst