### PR TITLE
header-html and footer-html in all the generation methods

### DIFF
--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -58,6 +58,36 @@ class Pdf extends AbstractGenerator
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function generateFromHtml($html, $output, array $options = array(), $overwrite = false)
+    {
+        $options = $this->handleOptions($options);
+
+        return parent::generateFromHtml($html, $output, $options, $overwrite);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOutput($input, array $options = array())
+    {
+        $options = $this->handleOptions($options);
+
+        return parent::getOutput($input, $options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOutputFromHtml($html, array $options = array())
+    {
+        $options = $this->handleOptions($options);
+
+        return parent::getOutputFromHtml($html, $options);
+    }
+
+    /**
      * @param array $options
      * @return bool
      */


### PR DESCRIPTION
#33 added a handy handleOptions() method and overrided the generate() method to make use of the handleOptions(). But the methods generateFromHtml(), getOutput(), getOutputFromHtml() don't have this implementation.. a bit weird if you ask me