### PR TITLE
Distant xsl stylesheets and more

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -101,6 +101,17 @@ $snappy = new Pdf($myProjectDirectory . '/vendor/h4cc/wkhtmltopdf-i386/bin/wkhtm
 $snappy = new Pdf($myProjectDirectory . '/vendor/h4cc/wkhtmltopdf-amd64/bin/wkhtmltopdf-amd64');
 ```
 
+## Some use cases
+
+If you want to generate table of contents and you want to use custom XSL stylesheet, do the following
+```
+<?php
+$snappy = new Pdf('/path/to/binary');
+
+$snappy->setOption('toc', true);
+$snappy->setOption('xsl-style-sheet', 'http://path/to/stylesheet.xsl') //or local file;
+
+$snappy->generateFromHtml('<p>Some content</p>', 'test.pdf');
 
 ## Credits
 

--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -33,9 +33,13 @@ class Pdf extends AbstractGenerator
     protected function handleOptions(array $options = array())
     {
         foreach ($options as $option => $value) {
-            if (in_array($option, $this->optionsWithContentCheck)) {
-                $fileContent = $this->isOptionUrl($value) ? file_get_contents($value) : $value;
-                $options[$option] = $this->createTemporaryFile($fileContent, 'html');
+            if(null === $value){
+                unset($options[$option]);
+                continue;
+            }
+            if (array_key_exists($option, $this->optionsWithContentCheck)) {
+                $fileContent = $value && $this->isOptionUrl($value) ? file_get_contents($value) : $value;
+                $options[$option] = $this->createTemporaryFile($fileContent, $this->optionsWithContentCheck[$option]);
             }
         }
 
@@ -47,7 +51,7 @@ class Pdf extends AbstractGenerator
      */
     public function generate($input, $output, array $options = array(), $overwrite = false)
     {
-        $options = $this->handleOptions($options);
+        $options = $this->handleOptions(array_merge($this->getOptions(), $options));
 
         parent::generate($input, $output, $options, $overwrite);
     }
@@ -199,10 +203,10 @@ class Pdf extends AbstractGenerator
     protected function setOptionsWithContentCheck()
     {
         $this->optionsWithContentCheck = array(
-            'header-html',
-            'footer-html',
-            'cover',
-            'xsl-style-sheet',
+            'header-html'    => 'html',
+            'footer-html'    => 'html',
+            'cover'          => 'html',
+            'xsl-style-sheet'=> 'xsl',
         );
     }
 }

--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -51,7 +51,7 @@ class Pdf extends AbstractGenerator
      */
     public function generate($input, $output, array $options = array(), $overwrite = false)
     {
-        $options = $this->handleOptions(array_merge($this->getOptions(), $options));
+        $options = $this->handleOptions($this->mergeOptions($options));
 
         parent::generate($input, $output, $options, $overwrite);
     }

--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -33,7 +33,7 @@ class Pdf extends AbstractGenerator
     protected function handleOptions(array $options = array())
     {
         foreach ($options as $option => $value) {
-            if(null === $value){
+            if (null === $value) {
                 unset($options[$option]);
                 continue;
             }

--- a/test/Knp/Snappy/PdfTest.php
+++ b/test/Knp/Snappy/PdfTest.php
@@ -48,7 +48,6 @@ class PdfTest extends \PHPUnit_Framework_TestCase
         $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer', 'xsl-style-sheet' => 'http://google.com'));
         $this->assertRegExp("/emptyBinary --lowquality --footer-html '.*.html' --xsl-style-sheet '.*.xsl' '.*.html' '.*.pdf'/", $testObject->getLastCommand());
     }
-
 }
 
 class PdfSpy extends Pdf

--- a/test/Knp/Snappy/PdfTest.php
+++ b/test/Knp/Snappy/PdfTest.php
@@ -41,6 +41,14 @@ class PdfTest extends \PHPUnit_Framework_TestCase
         $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer'));
     }
 
+    public function testOptionsAreCorrectlySavedIfItIsLocalOrRemoteContent(){
+        $testObject = new PdfSpy();
+        $testObject->setTemporaryFolder(__DIR__);
+
+        $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer', 'xsl-style-sheet' => 'http://google.com'));
+        $this->assertRegExp("/emptyBinary --lowquality --footer-html '.*.html' --xsl-style-sheet '.*.html' '.*.html' '.*.pdf'/", $testObject->getLastCommand());
+    }
+
 }
 
 class PdfSpy extends Pdf

--- a/test/Knp/Snappy/PdfTest.php
+++ b/test/Knp/Snappy/PdfTest.php
@@ -46,7 +46,7 @@ class PdfTest extends \PHPUnit_Framework_TestCase
         $testObject->setTemporaryFolder(__DIR__);
 
         $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer', 'xsl-style-sheet' => 'http://google.com'));
-        $this->assertRegExp("/emptyBinary --lowquality --footer-html '.*.html' --xsl-style-sheet '.*.html' '.*.html' '.*.pdf'/", $testObject->getLastCommand());
+        $this->assertRegExp("/emptyBinary --lowquality --footer-html '.*.html' --xsl-style-sheet '.*.xsl' '.*.html' '.*.pdf'/", $testObject->getLastCommand());
     }
 
 }


### PR DESCRIPTION
Summary of the PR:
1. Currently it allows to fetch content by URL and to store it in local temp file before passing it to wkhtmltopdf, closes https://github.com/KnpLabs/snappy/issues/149 and replaces PR https://github.com/KnpLabs/snappy/pull/151
2. Refactoring of the code. There was a copypaste of conditions and helper methods, it should be better now I hope
3. As a bonus, one of major bugs was discovered - when user calls 
```
$snappy->getOutputFromHtml($input, $output, $options)
```
```$options``` are not handled by Pdf::handleOptions, so there are possible failures as PR https://github.com/KnpLabs/snappy/pull/144 tries to solve.

@pilot what do you think?
