### PR TITLE
Hi, Please Update AbstractGenerator.php to add an extra param $force to setOptio…

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -88,10 +88,12 @@ abstract class AbstractGenerator implements GeneratorInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function setOption($name, $value)
+    public function setOption($name, $value, $force = false)
     {
-        if (!array_key_exists($name, $this->options)) {
-            throw new \InvalidArgumentException(sprintf('The option \'%s\' does not exist.', $name));
+        if(!$force) {
+            if (!array_key_exists($name, $this->options)) {
+                throw new \InvalidArgumentException(sprintf('The option \'%s\' does not exist.', $name));
+            }
         }
 
         $this->options[$name] = $value;


### PR DESCRIPTION
…nAllow additional options

Update setOption() method in AbstractGenerator.php to add an extra param $force for allowing additional options to be set / passed to wkhtmltopdf. This will be helpfull when we customize / enhance source of wkhtmltopdf. 

public function setOption($name, $value, $force = false)
    {
        if(!$force) {
            if (!array_key_exists($name, $this->options)) {
                throw new \InvalidArgumentException(sprintf('The option \'%s\' does not exist.', $name));
            }
        }

        $this->options[$name] = $value;
    }