### PR TITLE
fix tests on Windows

### DIFF
--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -483,7 +483,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 'http://the.url/',
                 '/the/path',
                 array(),
-                "{$theBinary} 'http://the.url/' '/the/path'"
+                $theBinary . ' ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
             ),
             array(
                 $theBinary,
@@ -494,7 +494,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                     'bar'   => false,
                     'baz'   => array()
                 ),
-                "{$theBinary} 'http://the.url/' '/the/path'"
+                $theBinary . ' ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
             ),
             array(
                 $theBinary,
@@ -505,7 +505,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                     'bar'   => array('barvalue1', 'barvalue2'),
                     'baz'   => true
                 ),
-                "{$theBinary} --foo 'foovalue' --bar 'barvalue1' --bar 'barvalue2' --baz 'http://the.url/' '/the/path'"
+                $theBinary . ' --foo ' . escapeshellarg('foovalue') . ' --bar ' . escapeshellarg('barvalue1') . ' --bar ' . escapeshellarg('barvalue2') . ' --baz ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
             ),
             array(
                 $theBinary,
@@ -515,7 +515,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                     'cookie'   => array('session' => 'bla', 'phpsess' => 12),
                     'no-background'   => '1',
                 ),
-                "{$theBinary} --cookie 'session' 'bla' --cookie 'phpsess' '12' --no-background '1' 'http://the.url/' '/the/path'"
+                $theBinary . ' --cookie ' . escapeshellarg('session') . ' ' . escapeshellarg('bla') . ' --cookie ' .  escapeshellarg('phpsess') . ' ' . escapeshellarg('12') . ' --no-background ' . escapeshellarg('1') . ' ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
             ),
             array(
                 $theBinary,
@@ -525,7 +525,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                     'allow'   => array('/path1', '/path2'),
                     'no-background'   => '1',
                 ),
-                "{$theBinary} --allow '/path1' --allow '/path2' --no-background '1' 'http://the.url/' '/the/path'"
+                $theBinary . ' --allow ' . escapeshellarg('/path1') . ' --allow ' . escapeshellarg('/path2') . ' --no-background ' . escapeshellarg('1') . ' ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
             ),
         );
     }

--- a/test/Knp/Snappy/PdfTest.php
+++ b/test/Knp/Snappy/PdfTest.php
@@ -4,6 +4,8 @@ namespace Knp\Snappy;
 
 class PdfTest extends \PHPUnit_Framework_TestCase
 {
+    const SHELL_ARG_QUOTE_REGEX = '(?:"|\')'; // escapeshellarg produces double quotes on Windows, single quotes otherwise
+
     public function testCreateInstance()
     {
         $testObject = new \Knp\Snappy\Pdf();
@@ -12,22 +14,24 @@ class PdfTest extends \PHPUnit_Framework_TestCase
 
     public function testThatSomething()
     {
+        $q = self::SHELL_ARG_QUOTE_REGEX;
         $testObject = new PdfSpy();
 
         $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer'));
-        $this->assertRegExp("/emptyBinary --lowquality --footer-html '.*' '.*' '.*'/", $testObject->getLastCommand());
+        $this->assertRegExp('/emptyBinary --lowquality --footer-html '.$q.'.*'.$q.' '.$q.'.*'.$q.' '.$q.'.*'.$q.'/', $testObject->getLastCommand());
 
         $testObject->getOutputFromHtml('<html></html>', array());
-        $this->assertRegExp("/emptyBinary --lowquality '.*' '.*'/", $testObject->getLastCommand());
+        $this->assertRegExp('/emptyBinary --lowquality '.$q.'.*'.$q.' '.$q.'.*'.$q.'/', $testObject->getLastCommand());
     }
 
     public function testThatSomethingUsingTmpFolder()
     {
+        $q = self::SHELL_ARG_QUOTE_REGEX;
         $testObject = new PdfSpy();
         $testObject->setTemporaryFolder(__DIR__);
 
         $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer'));
-        $this->assertRegExp("/emptyBinary --lowquality --footer-html '.*' '.*' '.*'/", $testObject->getLastCommand());
+        $this->assertRegExp('/emptyBinary --lowquality --footer-html '.$q.'.*'.$q.' '.$q.'.*'.$q.' '.$q.'.*'.$q.'/', $testObject->getLastCommand());
     }
 
     public function testThatSomethingUsingNonexistentTmpFolder()
@@ -40,12 +44,12 @@ class PdfTest extends \PHPUnit_Framework_TestCase
 
     public function testOptionsAreCorrectlySavedIfItIsLocalOrRemoteContent()
     {
+        $q = self::SHELL_ARG_QUOTE_REGEX;
         $testObject = new PdfSpy();
         $testObject->setTemporaryFolder(__DIR__);
 
         $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer', 'xsl-style-sheet' => 'http://google.com'));
-        $this->assertRegExp("/emptyBinary --lowquality --footer-html '.*.html' --xsl-style-sheet '.*.xsl' '.*.html' '.*.pdf'/", $testObject->getLastCommand());
-
+        $this->assertRegExp('/emptyBinary --lowquality --footer-html '.$q.'.*\.html'.$q.' --xsl-style-sheet '.$q.'.*\.xsl'.$q.' '.$q.'.*\.html'.$q.' '.$q.'.*\.pdf'.$q.'/', $testObject->getLastCommand());
     }
 
     public function testRemovesLocalFilesOnDestruct()


### PR DESCRIPTION
Because `escapeshellarg` produces double quotes on Windows, several tests used to be failing. With these changes, all tests pass on Windows.