### PR TITLE
fix passing a URL to options "footer-html", "header-html", "cover"

### DIFF
--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -26,7 +26,7 @@ class Pdf extends AbstractGenerator
     }
 
     /**
-     * handle options to transform HTML header-html or footer-html into files contains HTML
+     * Handle options to transform HTML strings into temporary files containing HTML
      * @param array $options
      * @return array $options Transformed options
      */
@@ -37,9 +37,15 @@ class Pdf extends AbstractGenerator
                 unset($options[$option]);
                 continue;
             }
-            if (array_key_exists($option, $this->optionsWithContentCheck)) {
-                $fileContent = $value && $this->isOptionUrl($value) ? file_get_contents($value) : $value;
-                $options[$option] = $this->createTemporaryFile($fileContent, $this->optionsWithContentCheck[$option]);
+
+            if (!empty($value) && array_key_exists($option, $this->optionsWithContentCheck)) {
+                $saveToTempFile = !$this->isFile($value) && !$this->isOptionUrl($value);
+                $fetchUrlContent = $option === 'xsl-style-sheet' && $this->isOptionUrl($value);
+
+                if ($saveToTempFile || $fetchUrlContent) {
+                    $fileContent = $fetchUrlContent ? file_get_contents($value) : $value;
+                    $options[$option] = $this->createTemporaryFile($fileContent, $this->optionsWithContentCheck[$option]);
+                }
             }
         }
 


### PR DESCRIPTION
With #160 merged, I've noticed an issue when a URL is given for the `footer-html` option. The content of that URL is fetched and saved into a temporary local file, its path is then passed to wkhtmltopdf, which finally exits with a `ProtocolUnknownError`. This PR fixes the issue by just passing the given URL again (as done before), while preserving the feature introduced by #160 of always downloading an XSL file and passing its temporary file path instead. I've also added some test cases to avoid further regressions.