### PR TITLE
Use composer require to install dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,24 +67,16 @@ $snappy->setOption('cache-dir', '/path/to/cache/dir');
 
 If you want to download wkhtmltopdf and wkhtmltoimage with composer you add to `composer.json`:
 
-```json
-{
-    "require": {
-        "h4cc/wkhtmltopdf-i386": "0.12.x",
-        "h4cc/wkhtmltoimage-i386": "0.12.x"
-    }
-}
+```bash
+$ composer require h4cc/wkhtmltopdf-i386 0.12.x
+$ composer require h4cc/wkhtmltoimage-i386 0.12.x
 ```
 
 or this if you are in 64 bit based system:
 
-```json
-{
-    "require": {
-        "h4cc/wkhtmltopdf-amd64": "0.12.x",
-        "h4cc/wkhtmltoimage-amd64": "0.12.x"
-    }
-}
+```bash
+$ composer require h4cc/wkhtmltopdf-amd64 0.12.x
+$ composer require h4cc/wkhtmltoimage-amd64 0.12.x
 ```
 
 And then you can use it


### PR DESCRIPTION
This is the preferred way of installing composer dependencies.