### PR TITLE
Cast returned status to integer

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -332,7 +332,7 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     protected function checkProcessStatus($status, $stdout, $stderr, $command)
     {
-        if (0 !== $status and '' !== $stderr) {
+        if (0 !== intval($status) and '' !== $stderr) {
             throw new \RuntimeException(sprintf(
                 'The exit status code \'%s\' says something went wrong:'."\n"
                 .'stderr: "%s"'."\n"


### PR DESCRIPTION
I started using wkhtmltopdf on 4th server and the returned status is '' (empty string) in case of success.
