### PR TITLE
Extend isFile with maximum path length check

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -591,7 +591,7 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     protected function isFile($filename)
     {
-        return is_file($filename);
+        return strlen($filename) <= 4096 && is_file($filename);
     }
 
     /**

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -591,7 +591,7 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     protected function isFile($filename)
     {
-        return strlen($filename) <= 4096 && is_file($filename);
+        return strlen($filename) <= PHP_MAXPATHLEN && is_file($filename);
     }
 
     /**


### PR DESCRIPTION
Added a simple check to isFile to check whether the length of the string exceeds the maximum (`PHP_MAXPATHLEN`). If so, `$filename` cannot be a file and further checking with `is_file` can be skipped (which generates a warning for long filenames).

Fixes KnpLabs/snappy#116
