### PR TITLE
Add keep/resolve relative links options

### DIFF
--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -201,6 +201,7 @@ class Pdf extends AbstractGenerator
             'redirect-delay'               => null, // old v0.9
             'cache-dir'                    => null,
             'keep-relative-links'          => null,
+            'resolve-relative-links'       => null,
         ));
     }
 

--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -200,6 +200,7 @@ class Pdf extends AbstractGenerator
             'viewport-size'                => null,
             'redirect-delay'               => null, // old v0.9
             'cache-dir'                    => null,
+            'keep-relative-links'          => null,
         ));
     }
 


### PR DESCRIPTION
Since release 0.12.3, two flags were added to wkhtmlpdf:
`--keep-relative-links` and `--resolve-relative-links`
https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.3

These control wkhtmlpdf's behaviour regarding relative links which is discussed here:
https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1843

I think these options should be added to snappy's options so we can use them with Snappy.