### PR TITLE
Changed array to use short syntax

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -16,7 +16,7 @@ use Symfony\Component\Process\Process;
 abstract class AbstractGenerator implements GeneratorInterface
 {
     private $binary;
-    private $options = array();
+    private $options = [];
     private $env;
     private $timeout = false;
     private $defaultExtension;
@@ -29,7 +29,7 @@ abstract class AbstractGenerator implements GeneratorInterface
     /**
      * @var array
      */
-    public $temporaryFiles = array();
+    public $temporaryFiles = [];
 
     /**
      * Constructor
@@ -38,7 +38,7 @@ abstract class AbstractGenerator implements GeneratorInterface
      * @param array  $options
      * @param array  $env
      */
-    public function __construct($binary, array $options = array(), array $env = null)
+    public function __construct($binary, array $options = [], array $env = null)
     {
         $this->configure();
 
@@ -46,7 +46,7 @@ abstract class AbstractGenerator implements GeneratorInterface
         $this->setOptions($options);
         $this->env = empty($env) ? null : $env;
 
-        register_shutdown_function(array($this, 'removeTemporaryFiles'));
+        register_shutdown_function([$this, 'removeTemporaryFiles']);
     }
 
     public function __destruct()
@@ -135,7 +135,7 @@ abstract class AbstractGenerator implements GeneratorInterface
     /**
      * {@inheritDoc}
      */
-    public function generate($input, $output, array $options = array(), $overwrite = false)
+    public function generate($input, $output, array $options = [], $overwrite = false)
     {
         if (null === $this->binary) {
             throw new \LogicException(
@@ -156,9 +156,9 @@ abstract class AbstractGenerator implements GeneratorInterface
     /**
      * {@inheritDoc}
      */
-    public function generateFromHtml($html, $output, array $options = array(), $overwrite = false)
+    public function generateFromHtml($html, $output, array $options = [], $overwrite = false)
     {
-        $fileNames = array();
+        $fileNames = [];
         if (is_array($html)) {
             foreach ($html as $htmlInput) {
                 $fileNames[] = $this->createTemporaryFile($htmlInput, 'html');
@@ -173,7 +173,7 @@ abstract class AbstractGenerator implements GeneratorInterface
     /**
      * {@inheritDoc}
      */
-    public function getOutput($input, array $options = array())
+    public function getOutput($input, array $options = [])
     {
         $filename = $this->createTemporaryFile(null, $this->getDefaultExtension());
 
@@ -187,9 +187,9 @@ abstract class AbstractGenerator implements GeneratorInterface
     /**
      * {@inheritDoc}
      */
-    public function getOutputFromHtml($html, array $options = array())
+    public function getOutputFromHtml($html, array $options = [])
     {
-        $fileNames = array();
+        $fileNames = [];
         if (is_array($html)) {
             foreach ($html as $htmlInput) {
                 $fileNames[] = $this->createTemporaryFile($htmlInput, 'html');
@@ -233,7 +233,7 @@ abstract class AbstractGenerator implements GeneratorInterface
      *
      * @return string
      */
-    public function getCommand($input, $output, array $options = array())
+    public function getCommand($input, $output, array $options = [])
     {
         $options = $this->mergeOptions($options);
 
@@ -399,7 +399,7 @@ abstract class AbstractGenerator implements GeneratorInterface
      *
      * @return string
      */
-    protected function buildCommand($binary, $input, $output, array $options = array())
+    protected function buildCommand($binary, $input, $output, array $options = [])
     {
         $command = $binary;
         $escapedBinary = escapeshellarg($binary);
@@ -431,7 +431,7 @@ abstract class AbstractGenerator implements GeneratorInterface
 
                 } else {
                     // Dont't add '--' if option is "cover"  or "toc".
-                    if (in_array($key, array('toc', 'cover'))) {
+                    if (in_array($key, ['toc', 'cover'])) {
                         $command .= ' '.$key.' '.escapeshellarg($option);
                     } else {
                         $command .= ' --'.$key.' '.escapeshellarg($option);
@@ -483,11 +483,11 @@ abstract class AbstractGenerator implements GeneratorInterface
 
         $process->run();
 
-        return array(
+        return [
             $process->getExitCode(),
             $process->getOutput(),
             $process->getErrorOutput(),
-        );
+        ];
     }
 
     /**

--- a/src/Knp/Snappy/GeneratorInterface.php
+++ b/src/Knp/Snappy/GeneratorInterface.php
@@ -20,7 +20,7 @@ interface GeneratorInterface
      * @param  array  $options An array of options for this generation only
      * @param  bool   $overwrite Overwrite the file if it exists. If not, throw a FileAlreadyExistsException
      */
-    public function generate($input, $output, array $options = array(), $overwrite = false);
+    public function generate($input, $output, array $options = [], $overwrite = false);
 
     /**
      * Generates the output media file from the given HTML
@@ -30,7 +30,7 @@ interface GeneratorInterface
      * @param  array  $options An array of options for this generation only
      * @param  bool   $overwrite Overwrite the file if it exists. If not, throw a FileAlreadyExistsException
      */
-    public function generateFromHtml($html, $output, array $options = array(), $overwrite = false);
+    public function generateFromHtml($html, $output, array $options = [], $overwrite = false);
 
     /**
      * Returns the output of the media generated from the specified input HTML
@@ -41,7 +41,7 @@ interface GeneratorInterface
      *
      * @return string
      */
-    public function getOutput($input, array $options = array());
+    public function getOutput($input, array $options = []);
 
     /**
      * Returns the output of the media generated from the given HTML
@@ -51,5 +51,5 @@ interface GeneratorInterface
      *
      * @return string
      */
-    public function getOutputFromHtml($html, array $options = array());
+    public function getOutputFromHtml($html, array $options = []);
 }

--- a/src/Knp/Snappy/Image.php
+++ b/src/Knp/Snappy/Image.php
@@ -15,7 +15,7 @@ class Image extends AbstractGenerator
     /**
      * {@inheritDoc}
      */
-    public function __construct($binary = null, array $options = array(), array $env = null)
+    public function __construct($binary = null, array $options = [], array $env = null)
     {
         $this->setDefaultExtension('jpg');
 
@@ -31,13 +31,13 @@ class Image extends AbstractGenerator
             'allow'                        => null,    // Allow the file or files from the specified folder to be loaded (repeatable)
             'checkbox-checked-svg'         => null,    // Use this SVG file when rendering checked checkboxes
             'checked-svg'                  => null,    // Use this SVG file when rendering unchecked checkboxes
-            'cookie'                       => array(), // Set an additional cookie (repeatable)
+            'cookie'                       => [],      // Set an additional cookie (repeatable)
             'cookie-jar'                   => null,    // Read and write cookies from and to the supplied cookie jar file
             'crop-h'                       => null,    // Set height for cropping
             'crop-w'                       => null,    // Set width for cropping
             'crop-x'                       => null,    // Set x coordinate for cropping (default 0)
             'crop-y'                       => null,    // Set y coordinate for cropping (default 0)
-            'custom-header'                => array(), // Set an additional HTTP header (repeatable)
+            'custom-header'                => [],      // Set an additional HTTP header (repeatable)
             'custom-header-propagation'    => null,    // Add HTTP headers specified by --custom-header for each resource request.
             'no-custom-header-propagation' => null,    // Do not add HTTP headers specified by --custom-header for each resource request.
             'debug-javascript'             => null,    // Show javascript debugging output
@@ -58,8 +58,8 @@ class Image extends AbstractGenerator
             'password'                     => null,    // HTTP Authentication password
             'disable-plugins'              => null,    // Disable installed plugins (default)
             'enable-plugins'               => null,    // Enable installed plugins (plugins will likely not work)
-            'post'                         => array(), // Add an additional post field
-            'post-file'                    => array(), // Post an additional file
+            'post'                         => [],      // Add an additional post field
+            'post-file'                    => [],      // Post an additional file
             'proxy'                        => null,    // Use a proxy
             'quality'                      => null,    // Output image quality (between 0 and 100) (default 94)
             'radiobutton-checked-svg'      => null,    // Use this SVG file when rendering checked radio-buttons

--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -12,12 +12,12 @@ namespace Knp\Snappy;
  */
 class Pdf extends AbstractGenerator
 {
-    protected $optionsWithContentCheck = array();
+    protected $optionsWithContentCheck = [];
 
     /**
      * {@inheritDoc}
      */
-    public function __construct($binary = null, array $options = array(), array $env = null)
+    public function __construct($binary = null, array $options = [], array $env = null)
     {
         $this->setDefaultExtension('pdf');
         $this->setOptionsWithContentCheck();
@@ -30,7 +30,7 @@ class Pdf extends AbstractGenerator
      * @param array $options
      * @return array $options Transformed options
      */
-    protected function handleOptions(array $options = array())
+    protected function handleOptions(array $options = [])
     {
         foreach ($options as $option => $value) {
             if (null === $value) {
@@ -55,7 +55,7 @@ class Pdf extends AbstractGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate($input, $output, array $options = array(), $overwrite = false)
+    public function generate($input, $output, array $options = [], $overwrite = false)
     {
         $options = $this->handleOptions($this->mergeOptions($options));
 
@@ -77,7 +77,7 @@ class Pdf extends AbstractGenerator
      */
     protected function configure()
     {
-        $this->addOptions(array(
+        $this->addOptions([
             'ignore-load-errors'           => null, // old v0.9
             'lowquality'                   => true,
             'collate'                      => null,
@@ -202,7 +202,7 @@ class Pdf extends AbstractGenerator
             'cache-dir'                    => null,
             'keep-relative-links'          => null,
             'resolve-relative-links'       => null,
-        ));
+        ]);
     }
 
     /**
@@ -210,11 +210,11 @@ class Pdf extends AbstractGenerator
      */
     protected function setOptionsWithContentCheck()
     {
-        $this->optionsWithContentCheck = array(
+        $this->optionsWithContentCheck = [
             'header-html'    => 'html',
             'footer-html'    => 'html',
             'cover'          => 'html',
             'xsl-style-sheet'=> 'xsl',
-        );
+        ];
     }
 }

--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -6,30 +6,30 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function testAddOption()
     {
-        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', array(), '', false);
+        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', [], '', false);
 
-        $this->assertEquals(array(), $media->getOptions());
+        $this->assertEquals([], $media->getOptions());
 
         $r = new \ReflectionMethod($media, 'addOption');
         $r->setAccessible(true);
-        $r->invokeArgs($media, array('foo', 'bar'));
+        $r->invokeArgs($media, ['foo', 'bar']);
 
-        $this->assertEquals(array('foo' => 'bar'), $media->getOptions(), '->addOption() adds an option');
+        $this->assertEquals(['foo' => 'bar'], $media->getOptions(), '->addOption() adds an option');
 
-        $r->invokeArgs($media, array('baz', 'bat'));
+        $r->invokeArgs($media, ['baz', 'bat']);
 
         $this->assertEquals(
-            array(
+            [
                 'foo' => 'bar',
                 'baz' => 'bat'
-            ),
+            ],
             $media->getOptions(),
             '->addOption() appends the option to the existing ones'
         );
 
         $message = '->addOption() raises an exception when the specified option already exists';
         try {
-            $r->invokeArgs($media, array('baz', 'bat'));
+            $r->invokeArgs($media, ['baz', 'bat']);
             $this->fail($message);
         } catch (\InvalidArgumentException $e) {
             $this->anything($message);
@@ -38,39 +38,39 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testAddOptions()
     {
-        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', array(), '', false);
+        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', [], '', false);
 
-        $this->assertEquals(array(), $media->getOptions());
+        $this->assertEquals([], $media->getOptions());
 
         $r = new \ReflectionMethod($media, 'addOptions');
         $r->setAccessible(true);
-        $r->invokeArgs($media, array(array('foo' => 'bar', 'baz' => 'bat')));
+        $r->invokeArgs($media, [['foo' => 'bar', 'baz' => 'bat']]);
 
         $this->assertEquals(
-            array(
+            [
                 'foo' => 'bar',
                 'baz' => 'bat'
-            ),
+            ],
             $media->getOptions(),
             '->addOptions() adds all the given options'
         );
 
-        $r->invokeArgs($media, array(array('ban' => 'bag', 'bal' => 'bac')));
+        $r->invokeArgs($media, [['ban' => 'bag', 'bal' => 'bac']]);
 
         $this->assertEquals(
-            array(
+            [
                 'foo' => 'bar',
                 'baz' => 'bat',
                 'ban' => 'bag',
                 'bal' => 'bac'
-            ),
+            ],
             $media->getOptions(),
             '->addOptions() adds the given options to the existing ones'
         );
 
         $message = '->addOptions() raises an exception when one of the given options already exists';
         try {
-            $r->invokeArgs($media, array(array('bak' => 'bam', 'bah' => 'bap', 'baz' => 'bat')));
+            $r->invokeArgs($media, [['bak' => 'bam', 'bah' => 'bap', 'baz' => 'bat']]);
             $this->fail($message);
         } catch (\InvalidArgumentException $e) {
             $this->anything($message);
@@ -79,18 +79,18 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetOption()
     {
-        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', array(), '', false);
+        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', [], '', false);
 
         $r = new \ReflectionMethod($media, 'addOption');
         $r->setAccessible(true);
-        $r->invokeArgs($media, array('foo', 'bar'));
+        $r->invokeArgs($media, ['foo', 'bar']);
 
         $media->setOption('foo', 'abc');
 
         $this->assertEquals(
-            array(
+            [
                 'foo' => 'abc'
-            ),
+            ],
             $media->getOptions(),
             '->setOption() defines the value of an option'
         );
@@ -106,26 +106,26 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetOptions()
     {
-        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', array(), '', false);
+        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', [], '', false);
 
         $r = new \ReflectionMethod($media, 'addOptions');
         $r->setAccessible(true);
-        $r->invokeArgs($media, array(array('foo' => 'bar', 'baz' => 'bat')));
+        $r->invokeArgs($media, [['foo' => 'bar', 'baz' => 'bat']]);
 
-        $media->setOptions(array('foo' => 'abc', 'baz' => 'def'));
+        $media->setOptions(['foo' => 'abc', 'baz' => 'def']);
 
         $this->assertEquals(
-            array(
+            [
                 'foo'   => 'abc',
                 'baz'   => 'def'
-            ),
+            ],
             $media->getOptions(),
             '->setOptions() defines the values of all the specified options'
         );
 
         $message = '->setOptions() raises an exception when one of the specified options does not exist';
         try {
-            $media->setOptions(array('foo' => 'abc', 'baz' => 'def', 'bad' => 'ghi'));
+            $media->setOptions(['foo' => 'abc', 'baz' => 'def', 'bad' => 'ghi']);
             $this->fail($message);
         } catch (\InvalidArgumentException $e) {
             $this->anything($message);
@@ -136,18 +136,18 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'prepareOutput',
                 'getCommand',
                 'executeCommand',
                 'checkOutput',
                 'checkProcessStatus',
-            ),
-            array(
+            ],
+            [
                 'the_binary',
-                array()
-            )
+                []
+            ]
         );
         $media
             ->expects($this->once())
@@ -160,7 +160,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             ->with(
                 $this->equalTo('the_input_file'),
                 $this->equalTo('the_output_file'),
-                $this->equalTo(array('foo' => 'bar'))
+                $this->equalTo(['foo' => 'bar'])
             )
             ->will($this->returnValue('the command'))
         ;
@@ -183,21 +183,21 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             )
         ;
 
-        $media->generate('the_input_file', 'the_output_file', array('foo' => 'bar'));
+        $media->generate('the_input_file', 'the_output_file', ['foo' => 'bar']);
     }
 
     public function testGenerateFromHtml()
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'generate',
                 'createTemporaryFile',
-            ),
-            array(
+            ],
+            [
                 'the_binary'
-            ),
+            ],
             '',
             false
         );
@@ -214,27 +214,27 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('generate')
             ->with(
-                $this->equalTo(array('the_temporary_file')),
+                $this->equalTo(['the_temporary_file']),
                 $this->equalTo('the_output_file'),
-                $this->equalTo(array('foo' => 'bar'))
+                $this->equalTo(['foo' => 'bar'])
             )
         ;
 
-        $media->generateFromHtml('<html>foo</html>', 'the_output_file', array('foo' => 'bar'));
+        $media->generateFromHtml('<html>foo</html>', 'the_output_file', ['foo' => 'bar']);
     }
 
     public function testGenerateFromHtmlWithHtmlArray()
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'generate',
                 'createTemporaryFile',
-            ),
-            array(
+            ],
+            [
                 'the_binary'
-            ),
+            ],
             '',
             false
         );
@@ -251,28 +251,28 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('generate')
             ->with(
-                $this->equalTo(array('the_temporary_file')),
+                $this->equalTo(['the_temporary_file']),
                 $this->equalTo('the_output_file'),
-                $this->equalTo(array('foo' => 'bar'))
+                $this->equalTo(['foo' => 'bar'])
             )
         ;
 
-        $media->generateFromHtml(array('<html>foo</html>'), 'the_output_file', array('foo' => 'bar'));
+        $media->generateFromHtml(['<html>foo</html>'], 'the_output_file', ['foo' => 'bar']);
     }
 
     public function testGetOutput()
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'getDefaultExtension',
                 'createTemporaryFile',
                 'generate',
                 'getFileContents',
                 'unlink'
-            ),
-            array(),
+            ],
+            [],
             '',
             false
         );
@@ -296,7 +296,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             ->with(
                 $this->equalTo('the_input_file'),
                 $this->equalTo('the_temporary_file'),
-                $this->equalTo(array('foo' => 'bar'))
+                $this->equalTo(['foo' => 'bar'])
             )
         ;
         $media
@@ -312,19 +312,19 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true))
         ;
 
-        $this->assertEquals('the file contents', $media->getOutput('the_input_file', array('foo' => 'bar')));
+        $this->assertEquals('the file contents', $media->getOutput('the_input_file', ['foo' => 'bar']));
     }
 
     public function testGetOutputFromHtml()
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'getOutput',
                 'createTemporaryFile',
-            ),
-            array(),
+            ],
+            [],
             '',
             false
         );
@@ -341,25 +341,25 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getOutput')
             ->with(
-                $this->equalTo(array('the_temporary_file')),
-                $this->equalTo(array('foo' => 'bar'))
+                $this->equalTo(['the_temporary_file']),
+                $this->equalTo(['foo' => 'bar'])
             )
             ->will($this->returnValue('the output'))
         ;
 
-        $this->assertEquals('the output', $media->getOutputFromHtml('<html>foo</html>', array('foo' => 'bar')));
+        $this->assertEquals('the output', $media->getOutputFromHtml('<html>foo</html>', ['foo' => 'bar']));
     }
 
     public function testGetOutputFromHtmlWithHtmlArray()
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'getOutput',
                 'createTemporaryFile',
-            ),
-            array(),
+            ],
+            [],
             '',
             false
         );
@@ -376,35 +376,35 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getOutput')
             ->with(
-                $this->equalTo(array('the_temporary_file')),
-                $this->equalTo(array('foo' => 'bar'))
+                $this->equalTo(['the_temporary_file']),
+                $this->equalTo(['foo' => 'bar'])
             )
             ->will($this->returnValue('the output'))
         ;
 
-        $this->assertEquals('the output', $media->getOutputFromHtml(array('<html>foo</html>'), array('foo' => 'bar')));
+        $this->assertEquals('the output', $media->getOutputFromHtml(['<html>foo</html>'], ['foo' => 'bar']));
     }
 
     public function testMergeOptions()
     {
-        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', array(), '', false);
+        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', [], '', false);
 
-        $originalOptions = array('foo' => 'bar', 'baz' => 'bat');
+        $originalOptions = ['foo' => 'bar', 'baz' => 'bat'];
 
         $addOptions = new \ReflectionMethod($media, 'addOptions');
         $addOptions->setAccessible(true);
-        $addOptions->invokeArgs($media, array($originalOptions));
+        $addOptions->invokeArgs($media, [$originalOptions]);
 
         $r = new \ReflectionMethod($media, 'mergeOptions');
         $r->setAccessible(true);
 
-        $mergedOptions = $r->invokeArgs($media, array(array('foo' => 'ban')));
+        $mergedOptions = $r->invokeArgs($media, [['foo' => 'ban']]);
 
         $this->assertEquals(
-            array(
+            [
                 'foo' => 'ban',
                 'baz' => 'bat'
-            ),
+            ],
             $mergedOptions,
             '->mergeOptions() merges an option to the instance ones and returns the result options array'
         );
@@ -415,20 +415,20 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             '->mergeOptions() does NOT change the instance options'
         );
 
-        $mergedOptions = $r->invokeArgs($media, array(array('foo' => 'ban', 'baz' => 'bag')));
+        $mergedOptions = $r->invokeArgs($media, [['foo' => 'ban', 'baz' => 'bag']]);
 
         $this->assertEquals(
-            array(
+            [
                 'foo' => 'ban',
                 'baz' => 'bag'
-            ),
+            ],
             $mergedOptions,
             '->mergeOptions() merges many options to the instance ones and returns the result options array'
         );
 
         $message = '->mergeOptions() throws an InvalidArgumentException once there is an undefined option in the given array';
         try {
-            $r->invokeArgs($media, array(array('foo' => 'ban', 'bad' => 'bah')));
+            $r->invokeArgs($media, [['foo' => 'ban', 'bad' => 'bah']]);
             $this->fail($message);
         } catch (\InvalidArgumentException $e) {
             $this->anything($message);
@@ -440,12 +440,12 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testBuildCommand($binary, $url, $path, $options, $expected)
     {
-        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', array(), '', false);
+        $media = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', [], '', false);
 
         $r = new \ReflectionMethod($media, 'buildCommand');
         $r->setAccessible(true);
 
-        $this->assertEquals($expected, $r->invokeArgs($media, array($binary, $url, $path, $options)));
+        $this->assertEquals($expected, $r->invokeArgs($media, [$binary, $url, $path, $options]));
     }
 
     private function getPHPExecutableFromPath() {
@@ -477,69 +477,69 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $theBinary = $this->getPHPExecutableFromPath() . ' -v'; // i.e.: '/usr/bin/php -v'
 
-        return array(
-            array(
+        return [
+            [
                 $theBinary,
                 'http://the.url/',
                 '/the/path',
-                array(),
+                [],
                 $theBinary . ' ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
-            ),
-            array(
+            ],
+            [
                 $theBinary,
                 'http://the.url/',
                 '/the/path',
-                array(
+                [
                     'foo'   => null,
                     'bar'   => false,
-                    'baz'   => array()
-                ),
+                    'baz'   => []
+                ],
                 $theBinary . ' ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
-            ),
-            array(
+            ],
+            [
                 $theBinary,
                 'http://the.url/',
                 '/the/path',
-                array(
+                [
                     'foo'   => 'foovalue',
-                    'bar'   => array('barvalue1', 'barvalue2'),
+                    'bar'   => ['barvalue1', 'barvalue2'],
                     'baz'   => true
-                ),
+                ],
                 $theBinary . ' --foo ' . escapeshellarg('foovalue') . ' --bar ' . escapeshellarg('barvalue1') . ' --bar ' . escapeshellarg('barvalue2') . ' --baz ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
-            ),
-            array(
+            ],
+            [
                 $theBinary,
                 'http://the.url/',
                 '/the/path',
-                array(
-                    'cookie'   => array('session' => 'bla', 'phpsess' => 12),
+                [
+                    'cookie'   => ['session' => 'bla', 'phpsess' => 12],
                     'no-background'   => '1',
-                ),
+                ],
                 $theBinary . ' --cookie ' . escapeshellarg('session') . ' ' . escapeshellarg('bla') . ' --cookie ' .  escapeshellarg('phpsess') . ' ' . escapeshellarg('12') . ' --no-background ' . escapeshellarg('1') . ' ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
-            ),
-            array(
+            ],
+            [
                 $theBinary,
                 'http://the.url/',
                 '/the/path',
-                array(
-                    'allow'   => array('/path1', '/path2'),
+                [
+                    'allow'   => ['/path1', '/path2'],
                     'no-background'   => '1',
-                ),
+                ],
                 $theBinary . ' --allow ' . escapeshellarg('/path1') . ' --allow ' . escapeshellarg('/path2') . ' --no-background ' . escapeshellarg('1') . ' ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
-            ),
-        );
+            ],
+        ];
     }
 
     public function testCheckOutput()
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'fileExists',
                 'filesize'
-            ),
-            array(),
+            ],
+            [],
             '',
             false
         );
@@ -561,7 +561,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $message = '->checkOutput() checks both file existence and size';
         try {
-            $r->invokeArgs($media, array('the_output_file', 'the command'));
+            $r->invokeArgs($media, ['the_output_file', 'the command']);
             $this->anything($message);
         } catch (\RuntimeException $e) {
             $this->fail($message);
@@ -572,12 +572,12 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'fileExists',
                 'filesize'
-            ),
-            array(),
+            ],
+            [],
             '',
             false
         );
@@ -593,7 +593,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $message = '->checkOutput() throws an InvalidArgumentException when the file does not exist';
         try {
-            $r->invokeArgs($media, array('the_output_file', 'the command'));
+            $r->invokeArgs($media, ['the_output_file', 'the command']);
             $this->fail($message);
         } catch (\RuntimeException $e) {
             $this->anything($message);
@@ -604,12 +604,12 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'fileExists',
                 'filesize'
-            ),
-            array(),
+            ],
+            [],
             '',
             false
         );
@@ -631,7 +631,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $message = '->checkOutput() throws an InvalidArgumentException when the file is empty';
         try {
-            $r->invokeArgs($media, array('the_output_file', 'the command'));
+            $r->invokeArgs($media, ['the_output_file', 'the command']);
             $this->fail($message);
         } catch (\RuntimeException $e) {
             $this->anything($message);
@@ -642,10 +642,10 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
-            ),
-            array(),
+            ],
+            [],
             '',
             false
         );
@@ -654,21 +654,21 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
         $r->setAccessible(true);
 
         try {
-            $r->invokeArgs($media, array(0, '', '', 'the command'));
+            $r->invokeArgs($media, [0, '', '', 'the command']);
             $this->anything('0 status means success');
         } catch (\RuntimeException $e) {
             $this->fail('0 status means success');
         }
 
         try {
-            $r->invokeArgs($media, array(1, '', '', 'the command'));
+            $r->invokeArgs($media, [1, '', '', 'the command']);
             $this->anything('1 status means failure, but no stderr content');
         } catch (\RuntimeException $e) {
             $this->fail('1 status means failure, but no stderr content');
         }
 
         try {
-            $r->invokeArgs($media, array(1, '', 'Could not connect to X', 'the command'));
+            $r->invokeArgs($media, [1, '', 'Could not connect to X', 'the command']);
             $this->fail('1 status means failure');
         } catch (\RuntimeException $e) {
             $this->anything('1 status means failure');
@@ -680,11 +680,11 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsAssociativeArray($array, $isAssociativeArray)
     {
-        $generator = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', array(), '', false);
+        $generator = $this->getMockForAbstractClass('Knp\Snappy\AbstractGenerator', [], '', false);
 
         $r = new \ReflectionMethod($generator, 'isAssociativeArray');
         $r->setAccessible(true);
-        $this->assertEquals($isAssociativeArray, $r->invokeArgs($generator, array($array)));
+        $this->assertEquals($isAssociativeArray, $r->invokeArgs($generator, [$array]));
     }
 
     /**
@@ -694,12 +694,12 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $media = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'fileExists',
                 'isFile'
-            ),
-            array(),
+            ],
+            [],
             '',
             false
         );
@@ -716,100 +716,100 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
         $r = new \ReflectionMethod($media, 'prepareOutput');
         $r->setAccessible(true);
 
-        $r->invokeArgs($media, array('', false));
+        $r->invokeArgs($media, ['', false]);
     }
 
     public function dataForIsAssociativeArray()
     {
-        return array(
-            array(
-                array('key' => 'value'),
+        return [
+            [
+                ['key' => 'value'],
                 true
-            ),
-            array(
-                array('key' => 2),
+            ],
+            [
+                ['key' => 2],
                 true
-            ),
-            array(
-                array('key' => 'value', 'key2' => 'value2'),
+            ],
+            [
+                ['key' => 'value', 'key2' => 'value2'],
                 true
-            ),
-            array(
-                array(0 => 'value', 1 => 'value2', 'deux' => 'value3'),
+            ],
+            [
+                [0 => 'value', 1 => 'value2', 'deux' => 'value3'],
                 true
-            ),
-            array(
-                array(0 => 'value'),
+            ],
+            [
+                [0 => 'value'],
                 false
-            ),
-            array(
-                array(0 => 'value', 1 => 'value2', 3 => 'value3'),
+            ],
+            [
+                [0 => 'value', 1 => 'value2', 3 => 'value3'],
                 false
-            ),
-            array(
-                array('0' => 'value', '1' => 'value2', '3' => 'value3'),
+            ],
+            [
+                ['0' => 'value', '1' => 'value2', '3' => 'value3'],
                 false
-            ),
-            array(
-                array(),
+            ],
+            [
+                [],
                 false
-            ),
-        );
+            ],
+        ];
     }
-    
+
     public function testCleanupEmptyTemporaryFiles()
     {
         $generator = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'unlink',
-            ),
-            array(
+            ],
+            [
                 'the_binary'
-            )
+            ]
         );
         $generator
             ->expects($this->once())
             ->method('unlink');
-        
+
         $create = new \ReflectionMethod($generator, 'createTemporaryFile');
         $create->setAccessible(true);
         $create->invoke($generator, null, null);
-        
+
         $files = new \ReflectionProperty($generator, 'temporaryFiles');
         $files->setAccessible(true);
         $this->assertCount(1, $files->getValue($generator));
-        
+
         $remove = new \ReflectionMethod($generator, 'removeTemporaryFiles');
         $remove->setAccessible(true);
         $remove->invoke($generator);
     }
-    
+
     public function testleanupTemporaryFiles()
     {
         $generator = $this->getMock(
             'Knp\Snappy\AbstractGenerator',
-            array(
+            [
                 'configure',
                 'unlink',
-            ),
-            array(
+            ],
+            [
                 'the_binary'
-            )
+            ]
         );
         $generator
             ->expects($this->once())
             ->method('unlink');
-        
+
         $create = new \ReflectionMethod($generator, 'createTemporaryFile');
         $create->setAccessible(true);
         $create->invoke($generator, '<html/>', 'html');
-        
+
         $files = new \ReflectionProperty($generator, 'temporaryFiles');
         $files->setAccessible(true);
         $this->assertCount(1, $files->getValue($generator));
-        
+
         $remove = new \ReflectionMethod($generator, 'removeTemporaryFiles');
         $remove->setAccessible(true);
         $remove->invoke($generator);

--- a/test/Knp/Snappy/PdfTest.php
+++ b/test/Knp/Snappy/PdfTest.php
@@ -18,7 +18,7 @@ class PdfTest extends \PHPUnit_Framework_TestCase
         $testObject = new PdfSpy();
         $testObject->setTemporaryFolder(__DIR__);
 
-        $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer'));
+        $testObject->getOutputFromHtml('<html></html>', ['footer-html' => 'footer']);
         $this->assertRegExp('/emptyBinary --lowquality --footer-html '.$q.'.*'.$q.' '.$q.'.*'.$q.' '.$q.'.*'.$q.'/', $testObject->getLastCommand());
     }
 
@@ -27,7 +27,7 @@ class PdfTest extends \PHPUnit_Framework_TestCase
         $testObject = new PdfSpy();
         $testObject->setTemporaryFolder(__DIR__ . '/i-dont-exist');
 
-        $testObject->getOutputFromHtml('<html></html>', array('footer-html' => 'footer'));
+        $testObject->getOutputFromHtml('<html></html>', ['footer-html' => 'footer']);
     }
 
     /**
@@ -43,33 +43,33 @@ class PdfTest extends \PHPUnit_Framework_TestCase
     public function dataOptions() {
         $q = self::SHELL_ARG_QUOTE_REGEX;
 
-        return array(
+        return [
             // no options
-            array(
-                array(),
+            [
+                [],
                 '/emptyBinary --lowquality '.$q.'.*\.html'.$q.' '.$q.'.*\.pdf'.$q.'/',
-            ),
+            ],
             // just pass the given footer URL
-            array(
-                array('footer-html' => 'http://google.com'),
+            [
+                ['footer-html' => 'http://google.com'],
                 '/emptyBinary --lowquality --footer-html '.$q.'http:\/\/google\.com'.$q.' '.$q.'.*\.html'.$q.' '.$q.'.*\.pdf'.$q.'/',
-            ),
+            ],
             // just pass the given footer file
-            array(
-                array('footer-html' => __FILE__),
+            [
+                ['footer-html' => __FILE__],
                 '/emptyBinary --lowquality --footer-html '.$q.preg_quote(__FILE__, '/').$q.' '.$q.'.*\.html'.$q.' '.$q.'.*\.pdf'.$q.'/',
-            ),
+            ],
             // save the given footer HTML string into a temporary file and pass that filename
-            array(
-                array('footer-html' => 'footer'),
+            [
+                ['footer-html' => 'footer'],
                 '/emptyBinary --lowquality --footer-html '.$q.'.*\.html'.$q.' '.$q.'.*\.html'.$q.' '.$q.'.*\.pdf'.$q.'/',
-            ),
+            ],
             // save the content of the given XSL URL to a file and pass that filename
-            array(
-                array('xsl-style-sheet' => 'http://google.com'),
+            [
+                ['xsl-style-sheet' => 'http://google.com'],
                 '/emptyBinary --lowquality --xsl-style-sheet '.$q.'.*\.xsl'.$q.' '.$q.'.*\.html'.$q.' '.$q.'.*\.pdf'.$q.'/',
-            ),
-        );
+            ],
+        ];
     }
 
     public function testRemovesLocalFilesOnDestruct()
@@ -116,7 +116,7 @@ class PdfSpy extends Pdf
     protected function executeCommand($command)
     {
         $this->lastCommand = $command;
-        return array(0, 'output', 'errorOutput');
+        return [0, 'output', 'errorOutput'];
     }
 
     protected function checkOutput($output, $command)
@@ -124,7 +124,7 @@ class PdfSpy extends Pdf
         //let's say everything went right
     }
 
-    public function getOutput($input, array $options = array())
+    public function getOutput($input, array $options = [])
     {
         $filename = $this->createTemporaryFile(null, $this->getDefaultExtension());
         $this->generate($input, $filename, $options, true);


### PR DESCRIPTION
Since minimum required version of PHP is `>=5.6` I thought I'd change `array()` to short syntax `[]`.