### PR TITLE
image-dpi and image-quality must be passed as integers

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -433,6 +433,8 @@ abstract class AbstractGenerator implements GeneratorInterface
                     // Dont't add '--' if option is "cover"  or "toc".
                     if (in_array($key, array('toc', 'cover'))) {
                         $command .= ' '.$key.' '.escapeshellarg($option);
+                    } elseif (in_array($key, ['image-dpi', 'image-quality'])) {
+                        $command .= ' --'.$key.' '. (int) $option;
                     } else {
                         $command .= ' --'.$key.' '.escapeshellarg($option);
                     }

--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -527,6 +527,16 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
                 ),
                 $theBinary . ' --allow ' . escapeshellarg('/path1') . ' --allow ' . escapeshellarg('/path2') . ' --no-background ' . escapeshellarg('1') . ' ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
             ),
+            [
+                $theBinary,
+                'http://the.url/',
+                '/the/path',
+                [
+                    'image-dpi' => 100,
+                    'image-quality' => 50,
+                ],
+                $theBinary . ' ' . '--image-dpi 100 --image-quality 50 ' . escapeshellarg('http://the.url/') . ' ' . escapeshellarg('/the/path')
+            ],
         );
     }
 
@@ -756,7 +766,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
-    
+
     public function testCleanupEmptyTemporaryFiles()
     {
         $generator = $this->getMock(
@@ -772,20 +782,20 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator
             ->expects($this->once())
             ->method('unlink');
-        
+
         $create = new \ReflectionMethod($generator, 'createTemporaryFile');
         $create->setAccessible(true);
         $create->invoke($generator, null, null);
-        
+
         $files = new \ReflectionProperty($generator, 'temporaryFiles');
         $files->setAccessible(true);
         $this->assertCount(1, $files->getValue($generator));
-        
+
         $remove = new \ReflectionMethod($generator, 'removeTemporaryFiles');
         $remove->setAccessible(true);
         $remove->invoke($generator);
     }
-    
+
     public function testleanupTemporaryFiles()
     {
         $generator = $this->getMock(
@@ -801,15 +811,15 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator
             ->expects($this->once())
             ->method('unlink');
-        
+
         $create = new \ReflectionMethod($generator, 'createTemporaryFile');
         $create->setAccessible(true);
         $create->invoke($generator, '<html/>', 'html');
-        
+
         $files = new \ReflectionProperty($generator, 'temporaryFiles');
         $files->setAccessible(true);
         $this->assertCount(1, $files->getValue($generator));
-        
+
         $remove = new \ReflectionMethod($generator, 'removeTemporaryFiles');
         $remove->setAccessible(true);
         $remove->invoke($generator);


### PR DESCRIPTION
According to [wkhtmltopdf documentation](https://wkhtmltopdf.org/usage/wkhtmltopdf.txt), the values for `--image-dpi` and `--image-quality` options must be passed as integers. If they are not they simply get ignored. So far the `escapeshellarg` function has been used to escape the shell arguments, which adds single quotes around the value.

This patch adds a test for such case and implements a fix.