### PR TITLE
Add option to allow ignoring contentnotfound errors.

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -27,6 +27,11 @@ abstract class AbstractGenerator implements GeneratorInterface
     protected $temporaryFolder;
 
     /**
+     * @var boolean
+     */
+    protected $ignoreContentNotFound = false;
+
+    /**
      * @var array
      */
     public $temporaryFiles = [];
@@ -332,15 +337,19 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     protected function checkProcessStatus($status, $stdout, $stderr, $command)
     {
-        if (0 !== $status and '' !== $stderr) {
-            throw new \RuntimeException(sprintf(
-                'The exit status code \'%s\' says something went wrong:'."\n"
-                .'stderr: "%s"'."\n"
-                .'stdout: "%s"'."\n"
-                .'command: %s.',
-                $status, $stderr, $stdout, $command
-            ));
+        if  (0 === $status || '' === $stderr){
+            return;
         }
+        if ($this->isIgnoreContentNotFound() && 1 === $status && preg_match('/contentnotfound/i', $stderr)) {
+            return;
+        }
+        throw new \RuntimeException(sprintf(
+            'The exit status code \'%s\' says something went wrong:'."\n"
+            .'stderr: "%s"'."\n"
+            .'stdout: "%s"'."\n"
+            .'command: %s.',
+            $status, $stderr, $stdout, $command
+        ));
     }
 
     /**
@@ -556,6 +565,26 @@ abstract class AbstractGenerator implements GeneratorInterface
     public function setTemporaryFolder($temporaryFolder)
     {
         $this->temporaryFolder = $temporaryFolder;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIgnoreContentNotFound()
+    {
+        return $this->ignoreContentNotFound;
+    }
+
+    /**
+     * @param bool $ignoreContentNotFound
+     *
+     * @return AbstractGenerator
+     */
+    public function setIgnoreContentNotFound($ignoreContentNotFound)
+    {
+        $this->ignoreContentNotFound = $ignoreContentNotFound;
 
         return $this;
     }

--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -654,6 +654,7 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             'Knp\Snappy\AbstractGenerator',
             [
                 'configure',
+                'isIgnoreContentNotFound'
             ],
             [],
             '',
@@ -682,6 +683,17 @@ class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->fail('1 status means failure');
         } catch (\RuntimeException $e) {
             $this->anything('1 status means failure');
+        }
+
+        $media->expects($this->once())
+            ->method('isIgnoreContentNotFound')
+            ->will($this->returnValue(true))
+        ;
+        try {
+            $r->invokeArgs($media, [1, '', 'ContentNotFound', 'the command']);
+            $this->anything('1 with option ignorecontentnotfound means success');
+        } catch (\RuntimeException $e) {
+            $this->fail('1 status means failure, but ignorecontentnotfound is set');
         }
     }
 


### PR DESCRIPTION
Hi guys

I have been using this wrapper in a website application where users can generate their own website pages and render pdfs from it. Since it is possible for them to put outdated links to images or other urls in the pdf,  the snappy wrapper as of now always throws an exception. 

However I always wanted to be able to generate a preview for my users so they can visually see where they made any mistakes.

 For this I added an option to the AbstractGenerator.  It is basically just  a flag I set before rendering where I allow statuscode 1 in combination with the message contentnotfound.

For now I am using my own fork of snappy in my project but I wanted to give you guys the choice of potentially merging it back into the original.

Cheers,

Numkil