### PR TITLE
Use logger context instead of var_export

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -114,7 +114,7 @@ abstract class AbstractGenerator implements GeneratorInterface
 
         $this->options[$name] = $value;
 
-        $this->logger->debug(sprintf('Set option "%s" to "%s".', $name, var_export($value, true)));
+        $this->logger->debug(sprintf('Set option "%s".', $name), ['value' => $value]);
     }
 
     /**


### PR DESCRIPTION
Fixes #274

Doesn't var_export variables, but use the context option from the Log interface. This leaves the exporting to the logger.