### PR TITLE
Set env/logger/filesystem first

### DIFF
--- a/src/Knp/Snappy/Wkhtmltox/AbstractGenerator.php
+++ b/src/Knp/Snappy/Wkhtmltox/AbstractGenerator.php
@@ -41,13 +41,13 @@ abstract class AbstractGenerator implements LocalGenerator
      */
     public function __construct($binary, array $options = [], array $env = null)
     {
-        $this->configure();
-
-        $this->setBinary($binary);
-        $this->setOptions($options);
         $this->env = empty($env) ? null : $env;
         $this->logger = new NullLogger();
         $this->filesystem = new Filesystem();
+        
+        $this->configure();
+        $this->setBinary($binary);
+        $this->setOptions($options);
     }
 
     /**


### PR DESCRIPTION
When passing options as argument, it will trigger errors on `$this->logger->debug()`, because that doesn't exist yet.