### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7"
+        "phpunit/phpunit": "~4.8.36"
     },
     "suggest": {
         "h4cc/wkhtmltopdf-amd64": "Provides wkhtmltopdf-amd64 binary for Linux-compatible machines, use version `~0.12` as dependency",

--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -2,9 +2,10 @@
 
 namespace Knp\Snappy;
 
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
+class AbstractGeneratorTest extends TestCase
 {
     public function testAddOption()
     {

--- a/test/Knp/Snappy/ImageTest.php
+++ b/test/Knp/Snappy/ImageTest.php
@@ -2,7 +2,9 @@
 
 namespace Knp\Snappy;
 
-class ImageTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ImageTest extends TestCase
 {
     public function testCreateInstance()
     {

--- a/test/Knp/Snappy/PdfTest.php
+++ b/test/Knp/Snappy/PdfTest.php
@@ -2,7 +2,9 @@
 
 namespace Knp\Snappy;
 
-class PdfTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PdfTest extends TestCase
 {
     const SHELL_ARG_QUOTE_REGEX = '(?:"|\')'; // escapeshellarg produces double quotes on Windows, single quotes otherwise
 


### PR DESCRIPTION
#I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.

PS: I won't apply [this](https://styleci.io/analyses/8Q4xLO) StyleCI changes. There are not related to this PR :sweat_smile: 