### PR TITLE
Remove register_shutdown_function call

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -50,8 +50,6 @@ abstract class AbstractGenerator implements GeneratorInterface
         $this->setBinary($binary);
         $this->setOptions($options);
         $this->env = empty($env) ? null : $env;
-
-        register_shutdown_function([$this, 'removeTemporaryFiles']);
     }
 
     public function __destruct()


### PR DESCRIPTION
The temporary files are never being deleted.
Removing the register_shutdown_function() resolves the issue and allows the tmp files to get deleted.

The destructor should be sufficient as it will always get called when the object is destroyed.