### PR TITLE
Update AbstractGenerator.php to avoid null pointer exception

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -426,8 +426,10 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     public function removeTemporaryFiles()
     {
-        foreach ($this->temporaryFiles as $file) {
-            $this->unlink($file);
+        if(is_array($this->temporaryFiles)) {
+            foreach ($this->temporaryFiles as $file) {
+                $this->unlink($file);
+            }
         }
     }
 

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -426,7 +426,7 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     public function removeTemporaryFiles()
     {
-        if(is_array($this->temporaryFiles)) {
+        if (is_array($this->temporaryFiles)) {
             foreach ($this->temporaryFiles as $file) {
                 $this->unlink($file);
             }


### PR DESCRIPTION
Added a check on temporaryFiles to avoid null pointer exception
We are facing this error after upgrading to PHP 7.2:
`PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\ContextErrorException: Warning: Invalid argument supplied for foreach() in /var/www/project/vendor/knplabs/knp-snappy/src/Knp/Snappy/AbstractGenerator.php:429
Stack trace:
#0 /var/www/project/vendor/knplabs/knp-snappy/src/Knp/Snappy/AbstractGenerator.php(429): Symfony\Component\Debug\ErrorHandler->handleError(2, 'Invalid argumen...', '/var/www/projec...', 429, Array)
#1 [internal function]: Knp\Snappy\AbstractGenerator->removeTemporaryFiles()
#2 {main}
  thrown in /var/www/project/vendor/knplabs/knp-snappy/src/Knp/Snappy/AbstractGenerator.php on line 429`
This fix solves the issue.