### PR TITLE
Pass on error code in checkProcessStatus

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -55,6 +55,8 @@ tfoot { display:table-footer-group; }
 
 *A*: Please, check your `wkhtmltopdf` version. It is recommended to use at least `0.12.2.1` and what is important - starting from `wkhtmltopdf >= 0.12.2` it doesn't require X server or emulation anymore. You can download new version from http://wkhtmltopdf.org/downloads.html or install via composer for Linux servers as stated in [README](https://github.com/KnpLabs/snappy#wkhtmltopdf-binary-as-composer-dependencies). If there is no possibility to update `wkhtmltopdf`, please check http://stackoverflow.com/questions/9604625/wkhtmltopdf-cannot-connect-to-x-server
 
+###### *Q*: PDF generation failed with wkhtmltopdf returning error code 1 due to ContentNotFoundError, how do I deal with that?
+*A*: This is a known problem with wkhtmltopdf. Several issues has been raised: [issue 1855](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1855), [issue 2051](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2051). To catch that error, `generate` method will throw a `RuntimeException` with error code equals to the error code returned with wkhtmltopdf, catch this exception and check for the error code and then deal with this exception in appropriate ways.
 
 ###### *Q*: My PDF is always generated for a small screen resolution\I always receive a mobile version.
 

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -381,7 +381,7 @@ abstract class AbstractGenerator implements GeneratorInterface
                 . 'stdout: "%s"' . "\n"
                 . 'command: %s.',
                 $status, $stderr, $stdout, $command
-            ));
+            ), $status);
         }
     }
 

--- a/test/Knp/Snappy/AbstractGeneratorTest.php
+++ b/test/Knp/Snappy/AbstractGeneratorTest.php
@@ -779,8 +779,12 @@ class AbstractGeneratorTest extends TestCase
             $this->fail('1 status means failure, but no stderr content');
         }
 
-        $this->expectException(\RuntimeException::class);
-        $r->invokeArgs($media, [1, '', 'Could not connect to X', 'the command']);
+        try {
+            $r->invokeArgs($media, [1, '', 'Could not connect to X', 'the command']);
+            $this->fail('1 status means failure');
+        } catch (\RuntimeException $e) {
+            $this->assertEquals(1, $e->getCode(), 'Execption thrown by checkProcessStatus should pass on the error code');
+        }
     }
 
     /**


### PR DESCRIPTION
There is a known issue in wkhtmltopdf where it will generate the pdf and still return error code 1. People have opened issues in the past for this problem: #257  #90 .
By adding the error code to the exception thrown by checkProcessStatus, it gives the end user the ability to check for the error code and catch this exception and swallow it if possible.