### PR TITLE
Fix symfony/process 4.2 deprecation notice

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -516,7 +516,11 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     protected function executeCommand($command)
     {
-        $process = new Process($command, null, $this->env);
+        if (method_exists(Process::class, 'fromShellCommandline')) {
+            $process = Process::fromShellCommandline($command, null, $this->env);
+        } else {
+            $process = new Process($command, null, $this->env);
+        }
 
         if (false !== $this->timeout) {
             $process->setTimeout($this->timeout);


### PR DESCRIPTION
This fix the deprecated usage of Process::__construct with a string to describe the commande line.

See https://github.com/symfony/symfony/pull/27821. 