### PR TITLE
Fix documentation display PDF in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ $snappy->setBinary('/usr/local/bin/wkhtmltopdf');
 ```php
 $snappy = new Pdf('/usr/local/bin/wkhtmltopdf');
 header('Content-Type: application/pdf');
+echo $snappy->getOutput('http://www.github.com');
+```
+
+### Download the pdf from the browser
+
+```php
+$snappy = new Pdf('/usr/local/bin/wkhtmltopdf');
+header('Content-Type: application/pdf');
 header('Content-Disposition: attachment; filename="file.pdf"');
 echo $snappy->getOutput('http://www.github.com');
 ```


### PR DESCRIPTION
Content-Disposition header with attachment value say to browser to download the PDF but if we want only display, we need to remove this header. Web dev know that but cool to see correct terms in README 👍 