### PR TITLE
adding proxy-hostname-lookup option

### DIFF
--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -156,6 +156,7 @@ class Pdf extends AbstractGenerator
             'no-print-media-type'          => null,
             'bypass-proxy-for'             => null,
             'proxy'                        => null,
+            'proxy-hostname-lookup'        => null,
             'radiobutton-checked-svg'      => null,
             'radiobutton-svg'              => null,
             'run-script'                   => null,


### PR DESCRIPTION
Since the 0.12.5 wkhtmltopdf's version, you can use the `proxy-hostname-lookup` argument (https://github.com/wkhtmltopdf/wkhtmltopdf/pull/3628/files).

I added this option in the available options for snappy.
Usefull when you have to resolve you DNS with the specified proxy option :)

**Edit: additionnal information:**
This modification is very useful when you works with the new Symfony Binary and the symfony proxy option. Necessary to resolve the *.wip assets.
In our projects, we use this configuration to workaround:

```
knp_snappy:
    pdf:
        options:
            proxy: 127.0.0.1:7080
            proxy_hostname_lookup: true
```