### PR TITLE
Explicitly add maintainers in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ header('Content-Disposition: attachment; filename="file.pdf"');
 echo $snappy->getOutput(array('http://www.github.com','http://www.knplabs.com','http://www.php.net'));
 ```
 
-### Generate local pdf file 
+### Generate local pdf file
 ```php
 $snappy = new Pdf('/usr/local/bin/wkhtmltopdf');
 $snappy->generateFromHtml('<h1>Bill</h1><p>You owe me money, dude.</p>', '/tmp/bill-123.pdf');
@@ -117,7 +117,7 @@ $snappy = new Pdf($myProjectDirectory . '/vendor/h4cc/wkhtmltopdf-i386/bin/wkhtm
 $snappy = new Pdf($myProjectDirectory . '/vendor/h4cc/wkhtmltopdf-amd64/bin/wkhtmltopdf-amd64');
 ```
 
-*N.B.* These static binaries are extracted from  [Debian7 packages](https://github.com/h4cc/wkhtmltopdf-amd64/issues/13#issuecomment-150948179), so it might not be compatible with non-debian based linux distros 
+*N.B.* These static binaries are extracted from  [Debian7 packages](https://github.com/h4cc/wkhtmltopdf-amd64/issues/13#issuecomment-150948179), so it might not be compatible with non-debian based linux distros
 ## Some use cases
 
 If you want to generate table of contents and you want to use custom XSL stylesheet, do the following:
@@ -134,7 +134,7 @@ $snappy->generateFromHtml('<p>Some content</p>', 'test.pdf');
 
 ## Bugs & Support
 
-If you found a bug please fill a detailed issue with all the following points.  
+If you found a bug please fill a detailed issue with all the following points.
 If you need some help, please at least provide a complete reproducer so we could help you based on facts rather than assumptions.
 
 * OS and its version
@@ -142,6 +142,14 @@ If you need some help, please at least provide a complete reproducer so we could
 * A complete reproducer with relevant php and html/css/js code
 
 If your reproducer is big, please try to shrink it. It will help everyone to narrow the bug.
+
+## Maintainers
+
+KNPLabs is looking for maintainers ([see why](https://knplabs.com/en/blog/news-for-our-foss-projects-maintenance)).
+
+If you are interested, feel free to open a PR to ask to be added as a maintainer.
+
+We’ll be glad to hear from you :)
 
 ## Credits
 


### PR DESCRIPTION
As stated in
https://knplabs.com/en/blog/news-for-our-foss-projects-maintenance ,
we'd like to explicitly indicate who is maintaining the project, as the
KNP Labs organization is looking for maintainers.

If you are interested, feel free to open a PR to ask to be added as a maintainer. We’ll be glad to hear from you :)