### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,14 @@ init:
 
 install:
   - IF EXIST c:\tools\php (SET PHP=0)
+  - ps: Set-Service wuauserv -StartupType Manual
+  # In order to be able to list all the avialable PHP packages we have to
+  # downgrade Chocolatey to version 0.10.13.
+  # See https://github.com/chocolatey/choco/issues/1843
+  - ps: choco install chocolatey -y --version 0.10.13 --allow-downgrade --force
   - ps: choco search php --exact --all-versions -r
   - ps: echo ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-  - ps: appveyor-retry cinst php --params '""/InstallDir:c:\tools\php""' --ignore-checksums -y --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+  - ps: appveyor-retry cinst php --params '""/InstallDir:c:\tools\php""' --ignore-checksums -y --force --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
   - cd c:\tools\php
   - IF %PHP%==1 copy php.ini-production php.ini /Y
   - IF %PHP%==1 echo date.timezone="UTC" >> php.ini


### PR DESCRIPTION
In order to install the latest PHP version per every target specified we use `choco search php --exact --all-versions -r` command and then, we filter the returned versions to just get the latest one.

From Chocolatey's version `0.10.14` the above command started returning only the latest version available.
That change made impossible to find the latest PHP minor release version so, in order to fix it we have to downgrade Chocolatey to `0.10.13` version (ref https://github.com/chocolatey/choco/issues/1843).

I also had to disable Windows updates.