### PR TITLE
Explicitly implement LoggerAwareInterface

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -3,6 +3,7 @@
 namespace Knp\Snappy;
 
 use Knp\Snappy\Exception as Exceptions;
+use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Process\Process;
@@ -14,7 +15,7 @@ use Symfony\Component\Process\Process;
  * @author  Matthieu Bontemps <matthieu.bontemps@knplabs.com>
  * @author  Antoine Hérault <antoine.herault@knplabs.com>
  */
-abstract class AbstractGenerator implements GeneratorInterface
+abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInterface
 {
     private $binary;
     private $options = [];


### PR DESCRIPTION
I've explicity implemented LoggerAwareInterface on classes that have the setLogger(LoggerInterface $logger) method.

This will allow a DI container to automatically inject a logger.

(Updated version of #364) 