### PR TITLE
Increase phpstan level to 8

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,11 +2,13 @@ includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
 
 parameters:
-    level: 4
+    level: 8
     paths:
         - src/
         - tests/
     inferPrivatePropertyTypeFromConstructor: true
     reportUnmatchedIgnoredErrors: false
+    checkMissingIterableValueType: false
     ignoreErrors:
         - "#^Call to an undefined static method #"
+        - "#^Parameter \\#1 \\$command of class Symfony\\\\Component\\\\Process\\\\Process constructor expects array, string given\\.$#"

--- a/src/Knp/Snappy/GeneratorInterface.php
+++ b/src/Knp/Snappy/GeneratorInterface.php
@@ -19,7 +19,7 @@ interface GeneratorInterface
      * @param array        $options   An array of options for this generation only
      * @param bool         $overwrite Overwrite the file if it exists. If not, throw a FileAlreadyExistsException
      */
-    public function generate($input, $output, array $options = [], $overwrite = false);
+    public function generate($input, string $output, array $options = [], bool $overwrite = false): void;
 
     /**
      * Generates the output media file from the given HTML.
@@ -29,7 +29,7 @@ interface GeneratorInterface
      * @param array        $options   An array of options for this generation only
      * @param bool         $overwrite Overwrite the file if it exists. If not, throw a FileAlreadyExistsException
      */
-    public function generateFromHtml($html, $output, array $options = [], $overwrite = false);
+    public function generateFromHtml($html, string $output, array $options = [], bool $overwrite = false): void;
 
     /**
      * Returns the output of the media generated from the specified input HTML
@@ -40,7 +40,7 @@ interface GeneratorInterface
      *
      * @return string
      */
-    public function getOutput($input, array $options = []);
+    public function getOutput($input, array $options = []): string;
 
     /**
      * Returns the output of the media generated from the given HTML.
@@ -50,5 +50,5 @@ interface GeneratorInterface
      *
      * @return string
      */
-    public function getOutputFromHtml($html, array $options = []);
+    public function getOutputFromHtml($html, array $options = []): string;
 }

--- a/src/Knp/Snappy/Image.php
+++ b/src/Knp/Snappy/Image.php
@@ -14,7 +14,7 @@ class Image extends AbstractGenerator
     /**
      * {@inheritdoc}
      */
-    public function __construct($binary = null, array $options = [], array $env = null)
+    public function __construct(string $binary = null, array $options = [], array $env = null)
     {
         $this->setDefaultExtension('jpg');
 
@@ -24,7 +24,7 @@ class Image extends AbstractGenerator
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->addOptions([
             'allow'                        => null,    // Allow the file or files from the specified folder to be loaded (repeatable)

--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -11,12 +11,15 @@ namespace Knp\Snappy;
  */
 class Pdf extends AbstractGenerator
 {
+    /**
+     * @var array
+     */
     protected $optionsWithContentCheck = [];
 
     /**
      * {@inheritdoc}
      */
-    public function __construct($binary = null, array $options = [], array $env = null)
+    public function __construct(string $binary = null, array $options = [], array $env = null)
     {
         $this->setDefaultExtension('pdf');
         $this->setOptionsWithContentCheck();
@@ -31,7 +34,7 @@ class Pdf extends AbstractGenerator
      *
      * @return array $options Transformed options
      */
-    protected function handleOptions(array $options = [])
+    protected function handleOptions(array $options = []): array
     {
         foreach ($options as $option => $value) {
             if (null === $value) {
@@ -56,7 +59,7 @@ class Pdf extends AbstractGenerator
     /**
      * {@inheritdoc}
      */
-    public function generate($input, $output, array $options = [], $overwrite = false)
+    public function generate($input, string $output, array $options = [], bool $overwrite = false): void
     {
         $options = $this->handleOptions($this->mergeOptions($options));
 
@@ -70,7 +73,7 @@ class Pdf extends AbstractGenerator
      *
      * @return bool
      */
-    protected function isOptionUrl($option)
+    protected function isOptionUrl($option): bool
     {
         return (bool) filter_var($option, FILTER_VALIDATE_URL);
     }
@@ -78,7 +81,7 @@ class Pdf extends AbstractGenerator
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->addOptions([
             // Global options
@@ -226,7 +229,7 @@ class Pdf extends AbstractGenerator
     /**
      * Array with options which require to store the content of the option before passing it to wkhtmltopdf.
      */
-    protected function setOptionsWithContentCheck()
+    protected function setOptionsWithContentCheck(): self
     {
         $this->optionsWithContentCheck = [
             'header-html'    => 'html',
@@ -234,5 +237,7 @@ class Pdf extends AbstractGenerator
             'cover'          => 'html',
             'xsl-style-sheet'=> 'xsl',
         ];
+
+        return $this;
     }
 }

--- a/tests/Knp/Snappy/AbstractGeneratorTest.php
+++ b/tests/Knp/Snappy/AbstractGeneratorTest.php
@@ -8,7 +8,7 @@ use Psr\Log\LoggerInterface;
 
 class AbstractGeneratorTest extends TestCase
 {
-    public function testAddOption()
+    public function testAddOption(): void
     {
         $media = $this->getMockForAbstractClass(AbstractGenerator::class, [], '', false);
 
@@ -41,7 +41,7 @@ class AbstractGeneratorTest extends TestCase
         }
     }
 
-    public function testAddOptions()
+    public function testAddOptions(): void
     {
         $media = $this->getMockForAbstractClass(AbstractGenerator::class, [], '', false);
 
@@ -83,7 +83,7 @@ class AbstractGeneratorTest extends TestCase
         }
     }
 
-    public function testSetOption()
+    public function testSetOption(): void
     {
         $media = $this
             ->getMockBuilder(AbstractGenerator::class)
@@ -122,7 +122,7 @@ class AbstractGeneratorTest extends TestCase
         }
     }
 
-    public function testSetOptions()
+    public function testSetOptions(): void
     {
         $media = $this
             ->getMockBuilder(AbstractGenerator::class)
@@ -162,7 +162,7 @@ class AbstractGeneratorTest extends TestCase
         }
     }
 
-    public function testGenerate()
+    public function testGenerate(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -235,7 +235,7 @@ class AbstractGeneratorTest extends TestCase
         $media->generate('the_input_file', 'the_output_file', ['foo' => 'bar']);
     }
 
-    public function testFailingGenerate()
+    public function testFailingGenerate(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -304,7 +304,7 @@ class AbstractGeneratorTest extends TestCase
         $media->generate('the_input_file', 'the_output_file', ['foo' => 'bar']);
     }
 
-    public function testGenerateFromHtml()
+    public function testGenerateFromHtml(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -339,7 +339,7 @@ class AbstractGeneratorTest extends TestCase
         $media->generateFromHtml('<html>foo</html>', 'the_output_file', ['foo' => 'bar']);
     }
 
-    public function testGenerateFromHtmlWithHtmlArray()
+    public function testGenerateFromHtmlWithHtmlArray(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -373,7 +373,7 @@ class AbstractGeneratorTest extends TestCase
         $media->generateFromHtml(['<html>foo</html>'], 'the_output_file', ['foo' => 'bar']);
     }
 
-    public function testGetOutput()
+    public function testGetOutput(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -426,7 +426,7 @@ class AbstractGeneratorTest extends TestCase
         $this->assertEquals('the file contents', $media->getOutput('the_input_file', ['foo' => 'bar']));
     }
 
-    public function testGetOutputFromHtml()
+    public function testGetOutputFromHtml(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -459,7 +459,7 @@ class AbstractGeneratorTest extends TestCase
         $this->assertEquals('the output', $media->getOutputFromHtml('<html>foo</html>', ['foo' => 'bar']));
     }
 
-    public function testGetOutputFromHtmlWithHtmlArray()
+    public function testGetOutputFromHtmlWithHtmlArray(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -492,7 +492,7 @@ class AbstractGeneratorTest extends TestCase
         $this->assertEquals('the output', $media->getOutputFromHtml(['<html>foo</html>'], ['foo' => 'bar']));
     }
 
-    public function testMergeOptions()
+    public function testMergeOptions(): void
     {
         $media = $this->getMockForAbstractClass(AbstractGenerator::class, [], '', false);
 
@@ -546,7 +546,7 @@ class AbstractGeneratorTest extends TestCase
     /**
      * @dataProvider dataForBuildCommand
      */
-    public function testBuildCommand($binary, $url, $path, $options, $expected)
+    public function testBuildCommand(string $binary, string $url, string $path, array $options, string $expected): void
     {
         $media = $this->getMockForAbstractClass(AbstractGenerator::class, [], '', false);
 
@@ -556,7 +556,7 @@ class AbstractGeneratorTest extends TestCase
         $this->assertEquals($expected, $r->invokeArgs($media, [$binary, $url, $path, $options]));
     }
 
-    private function getPHPExecutableFromPath()
+    private function getPHPExecutableFromPath(): ?string
     {
         if (isset($_SERVER['_'])) {
             return $_SERVER['_'];
@@ -564,6 +564,10 @@ class AbstractGeneratorTest extends TestCase
 
         if (@defined(PHP_BINARY)) {
             return PHP_BINARY;
+        }
+
+        if (false === getenv('PATH')) {
+            return null;
         }
 
         $paths = explode(PATH_SEPARATOR, getenv('PATH'));
@@ -579,10 +583,10 @@ class AbstractGeneratorTest extends TestCase
             }
         }
 
-        return false; // not found
+        return null; // not found
     }
 
-    public function dataForBuildCommand()
+    public function dataForBuildCommand(): array
     {
         $theBinary = $this->getPHPExecutableFromPath() . ' -v'; // i.e.: '/usr/bin/php -v'
 
@@ -649,7 +653,7 @@ class AbstractGeneratorTest extends TestCase
         ];
     }
 
-    public function testCheckOutput()
+    public function testCheckOutput(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -686,7 +690,7 @@ class AbstractGeneratorTest extends TestCase
         }
     }
 
-    public function testCheckOutputWhenTheFileDoesNotExist()
+    public function testCheckOutputWhenTheFileDoesNotExist(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -717,7 +721,7 @@ class AbstractGeneratorTest extends TestCase
         }
     }
 
-    public function testCheckOutputWhenTheFileIsEmpty()
+    public function testCheckOutputWhenTheFileIsEmpty(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -755,7 +759,7 @@ class AbstractGeneratorTest extends TestCase
         }
     }
 
-    public function testCheckProcessStatus()
+    public function testCheckProcessStatus(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods(['configure'])
@@ -791,7 +795,7 @@ class AbstractGeneratorTest extends TestCase
     /**
      * @dataProvider dataForIsAssociativeArray
      */
-    public function testIsAssociativeArray($array, $isAssociativeArray)
+    public function testIsAssociativeArray(array $array, bool $isAssociativeArray): void
     {
         $generator = $this->getMockForAbstractClass(AbstractGenerator::class, [], '', false);
 
@@ -803,7 +807,7 @@ class AbstractGeneratorTest extends TestCase
     /**
      * @expectedException Knp\Snappy\Exception\FileAlreadyExistsException
      */
-    public function testItThrowsTheProperExceptionWhenFileExistsAndNotOverwritting()
+    public function testItThrowsTheProperExceptionWhenFileExistsAndNotOverwritting(): void
     {
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -831,7 +835,7 @@ class AbstractGeneratorTest extends TestCase
         $r->invokeArgs($media, ['', false]);
     }
 
-    public function dataForIsAssociativeArray()
+    public function dataForIsAssociativeArray(): array
     {
         return [
             [
@@ -869,7 +873,7 @@ class AbstractGeneratorTest extends TestCase
         ];
     }
 
-    public function testCleanupEmptyTemporaryFiles()
+    public function testCleanupEmptyTemporaryFiles(): void
     {
         $generator = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -897,7 +901,7 @@ class AbstractGeneratorTest extends TestCase
         $remove->invoke($generator);
     }
 
-    public function testleanupTemporaryFiles()
+    public function testleanupTemporaryFiles(): void
     {
         $generator = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
@@ -925,10 +929,10 @@ class AbstractGeneratorTest extends TestCase
         $remove->invoke($generator);
     }
 
-    public function testResetOptions()
+    public function testResetOptions(): void
     {
         $media = new class('/usr/local/bin/wkhtmltopdf') extends AbstractGenerator {
-            protected function configure()
+            protected function configure(): void
             {
                 $this->addOptions([
                     'optionA' => null,

--- a/tests/Knp/Snappy/ImageTest.php
+++ b/tests/Knp/Snappy/ImageTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class ImageTest extends TestCase
 {
-    public function testCreateInstance()
+    public function testCreateInstance(): void
     {
         $testObject = new Image();
         $this->assertInstanceOf(Image::class, $testObject);

--- a/tests/Knp/Snappy/PdfTest.php
+++ b/tests/Knp/Snappy/PdfTest.php
@@ -10,7 +10,7 @@ class PdfTest extends TestCase
 {
     const SHELL_ARG_QUOTE_REGEX = '(?:"|\')'; // escapeshellarg produces double quotes on Windows, single quotes otherwise
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $directory = __DIR__ . '/i-dont-exist';
 
@@ -39,13 +39,13 @@ class PdfTest extends TestCase
         }
     }
 
-    public function testCreateInstance()
+    public function testCreateInstance(): void
     {
         $testObject = new Pdf();
         $this->assertInstanceOf(Pdf::class, $testObject);
     }
 
-    public function testThatSomethingUsingTmpFolder()
+    public function testThatSomethingUsingTmpFolder(): void
     {
         $q = self::SHELL_ARG_QUOTE_REGEX;
         $testObject = new PdfSpy();
@@ -55,7 +55,7 @@ class PdfTest extends TestCase
         $this->assertRegExp('/emptyBinary --lowquality --footer-html ' . $q . '.*' . $q . ' ' . $q . '.*' . $q . ' ' . $q . '.*' . $q . '/', $testObject->getLastCommand());
     }
 
-    public function testThatSomethingUsingNonexistentTmpFolder()
+    public function testThatSomethingUsingNonexistentTmpFolder(): void
     {
         $temporaryFolder = sys_get_temp_dir() . '/i-dont-exist';
 
@@ -67,7 +67,7 @@ class PdfTest extends TestCase
         $this->assertDirectoryExists($temporaryFolder);
     }
 
-    public function testRemovesLocalFilesOnError()
+    public function testRemovesLocalFilesOnError(): void
     {
         $pdf = new PdfSpy();
         $method = new \ReflectionMethod($pdf, 'createTemporaryFile');
@@ -82,14 +82,14 @@ class PdfTest extends TestCase
     /**
      * @dataProvider dataOptions
      */
-    public function testOptions(array $options, $expectedRegex)
+    public function testOptions(array $options, string $expectedRegex): void
     {
         $testObject = new PdfSpy();
         $testObject->getOutputFromHtml('<html></html>', $options);
         $this->assertRegExp($expectedRegex, $testObject->getLastCommand());
     }
 
-    public function dataOptions()
+    public function dataOptions(): array
     {
         $q = self::SHELL_ARG_QUOTE_REGEX;
 
@@ -131,7 +131,7 @@ class PdfTest extends TestCase
         ];
     }
 
-    public function testRemovesLocalFilesOnDestruct()
+    public function testRemovesLocalFilesOnDestruct(): void
     {
         $pdf = new PdfSpy();
         $method = new \ReflectionMethod($pdf, 'createTemporaryFile');
@@ -146,6 +146,9 @@ class PdfTest extends TestCase
 
 class PdfSpy extends Pdf
 {
+    /**
+     * @var string
+     */
     private $lastCommand;
 
     public function __construct()
@@ -153,24 +156,24 @@ class PdfSpy extends Pdf
         parent::__construct('emptyBinary');
     }
 
-    public function getLastCommand()
+    public function getLastCommand(): string
     {
         return $this->lastCommand;
     }
 
-    protected function executeCommand($command)
+    protected function executeCommand(string $command): array
     {
         $this->lastCommand = $command;
 
         return [0, 'output', 'errorOutput'];
     }
 
-    protected function checkOutput($output, $command)
+    protected function checkOutput(string $output, string $command): void
     {
         //let's say everything went right
     }
 
-    public function getOutput($input, array $options = [])
+    public function getOutput($input, array $options = []): string
     {
         $filename = $this->createTemporaryFile(null, $this->getDefaultExtension());
         $this->generate($input, $filename, $options, true);


### PR DESCRIPTION
The error `Parameter #1 $command of class Symfony\Component\Process\Process constructor expects array, string given.` has been ignored because the `Symfony\Component\Process\Process` constructor is only called with a string as its first parameter on v3.4 (see [the condition above](https://github.com/KnpLabs/snappy/blob/master/src/Knp/Snappy/AbstractGenerator.php#L527-L531)) and on that version, calling it with a string it's still supported (that part of the code will be removed when the support for Symfony 3.4 will be removed).