### PR TITLE
Support multiple headers/footers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,29 @@ header('Content-Disposition: attachment; filename="file.pdf"');
 echo $snappy->getOutput(array('http://www.github.com','http://www.knplabs.com','http://www.php.net'));
 ```
 
+### Merge multiple urls into one pdf with different headers
+```php
+$snappy = new Pdf('/usr/local/bin/wkhtmltopdf');
+header('Content-Type: application/pdf');
+header('Content-Disposition: attachment; filename="file.pdf"');
+
+$urls = array();
+$urls[] = array(
+    'url' => 'http://www.github.com',
+    'options' => array(
+        'header-html' => 'header1.html'
+    )
+);
+$urls[] = array(
+    'url' => 'http://www.php.net',
+    'options' => array(
+        'header-html' => 'header2.html'
+    )
+);
+
+echo $snappy->getOutput($urls);
+```
+
 ### Generate local pdf file
 ```php
 $snappy = new Pdf('/usr/local/bin/wkhtmltopdf');

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -531,10 +531,14 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
                 $url = '';
                 $options = null;
 
-                if (is_array($i) || is_object($i)) {
-                    $url = $i['url'];
-                    if (null !== $i['options'] && false !== $i['options']) {
-                        $options = $this->buildOptions($i['options']);
+                if (is_array($i)) {
+                    if (null !== $i['url'] && false !== $i['url']) {
+                        $url = $i['url'];
+                        if (null !== $i['options'] && false !== $i['options']) {
+                            $options = $this->buildOptions($i['options']);
+                        }
+                    } else {
+                        throw new InvalidArgumentException(\sprintf('The url \'%s\' does not exist.', $name));
                     }
                 } else {
                     $url = $i;

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -513,48 +513,73 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
             $command = $escapedBinary;
         }
 
+        $command .= $this->buildOptions($options);
+
+        if (\is_array($input)) {
+            foreach ($input as $i) {
+                if (is_array($i) || is_object($i)) {
+                    if (null !== $i['options'] && false !== $i['options']) {
+                        $command .= ' ' . $this->buildOptions($i['options']);
+                    }
+                    $i = $i['file'];
+                }
+
+                $command .= ' ' . \escapeshellarg($i) . ' ';
+            }
+
+        } else {
+            $command .= ' ' . \escapeshellarg($input) . ' ';
+        }
+
+        $command .= \escapeshellarg($output);
+
+        return $command;
+    }
+
+    /**
+     * Builds the options of the command string.
+     *
+     * @param array        $options An array of options
+     *
+     * @return string
+     */
+    protected function buildOptions($options)
+    {
+        $optionString = '';
+
         foreach ($options as $key => $option) {
             if (null !== $option && false !== $option) {
                 if (true === $option) {
                     // Dont't put '--' if option is 'toc'.
                     if ($key === 'toc') {
-                        $command .= ' ' . $key;
+                        $optionString .= ' ' . $key;
                     } else {
-                        $command .= ' --' . $key;
+                        $optionString .= ' --' . $key;
                     }
                 } elseif (\is_array($option)) {
                     if ($this->isAssociativeArray($option)) {
                         foreach ($option as $k => $v) {
-                            $command .= ' --' . $key . ' ' . \escapeshellarg($k) . ' ' . \escapeshellarg($v);
+                            $optionString .= ' --' . $key . ' ' . \escapeshellarg($k) . ' ' . \escapeshellarg($v);
                         }
                     } else {
                         foreach ($option as $v) {
-                            $command .= ' --' . $key . ' ' . \escapeshellarg($v);
+                            $optionString .= ' --' . $key . ' ' . \escapeshellarg($v);
                         }
                     }
                 } else {
                     // Dont't add '--' if option is "cover"  or "toc".
                     if (\in_array($key, ['toc', 'cover'])) {
-                        $command .= ' ' . $key . ' ' . \escapeshellarg($option);
+                        $optionString .= ' ' . $key . ' ' . \escapeshellarg($option);
                     } elseif (\in_array($key, ['image-dpi', 'image-quality'])) {
-                        $command .= ' --' . $key . ' ' . (int) $option;
+                        $optionString .= ' --' . $key . ' ' . (int)$option;
                     } else {
-                        $command .= ' --' . $key . ' ' . \escapeshellarg($option);
+                        $optionString .= ' --' . $key . ' ' . \escapeshellarg($option);
                     }
                 }
             }
         }
 
-        if (\is_array($input)) {
-            foreach ($input as $i) {
-                $command .= ' ' . \escapeshellarg($i) . ' ';
-            }
-            $command .= \escapeshellarg($output);
-        } else {
-            $command .= ' ' . \escapeshellarg($input) . ' ' . \escapeshellarg($output);
-        }
-
-        return $command;
+        return $optionString;
     }
 
     /**

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -186,7 +186,17 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
 
         $command = $this->getCommand($input, $output, $options);
 
-        $inputFiles = \is_array($input) ? \implode('", "', $input) : $input;
+        $inputFiles = "";
+        if (is_array($input)) {
+            $urls = $input;
+            if (count($input) > 0 and is_array($input[0])) {
+                $urls = array_column($input, 'url');
+            }
+
+            $inputFiles = implode('", "', $urls);
+        } else {
+            $inputFiles = $input;
+        }
 
         $this->logger->info(\sprintf('Generate from file(s) "%s" to file "%s".', $inputFiles, $output), [
             'command' => $command,
@@ -516,15 +526,24 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
         $command .= $this->buildOptions($options);
 
         if (\is_array($input)) {
+
             foreach ($input as $i) {
+                $url = '';
+                $options = null;
+
                 if (is_array($i) || is_object($i)) {
+                    $url = $i['url'];
                     if (null !== $i['options'] && false !== $i['options']) {
-                        $command .= ' ' . $this->buildOptions($i['options']);
+                        $options = $this->buildOptions($i['options']);
                     }
-                    $i = $i['url'];
+                } else {
+                    $url = $i;
                 }
 
-                $command .= ' ' . \escapeshellarg($i) . ' ';
+                $command .= ' ' . \escapeshellarg($url) . ' ';
+                if (null !== $options) {
+                    $command .= ' ' . $options . ' ';
+                }
             }
 
         } else {

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -521,7 +521,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
                     if (null !== $i['options'] && false !== $i['options']) {
                         $command .= ' ' . $this->buildOptions($i['options']);
                     }
-                    $i = $i['file'];
+                    $i = $i['url'];
                 }
 
                 $command .= ' ' . \escapeshellarg($i) . ' ';

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -186,14 +186,14 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
 
         $command = $this->getCommand($input, $output, $options);
 
-        $inputFiles = "";
-        if (is_array($input)) {
+        $inputFiles = '';
+        if (\is_array($input)) {
             $urls = $input;
-            if (count($input) > 0 and is_array($input[0])) {
-                $urls = array_column($input, 'url');
+            if (\count($input) > 0 && \is_array($input[0])) {
+                $urls = \array_column($input, 'url');
             }
 
-            $inputFiles = implode('", "', $urls);
+            $inputFiles = \implode('", "', $urls);
         } else {
             $inputFiles = $input;
         }
@@ -526,12 +526,11 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
         $command .= $this->buildOptions($options);
 
         if (\is_array($input)) {
-
             foreach ($input as $i) {
                 $url = '';
                 $options = null;
 
-                if (is_array($i)) {
+                if (\is_array($i)) {
                     if (null !== $i['url'] && false !== $i['url']) {
                         $url = $i['url'];
                         if (null !== $i['options'] && false !== $i['options']) {
@@ -549,7 +548,6 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
                     $command .= ' ' . $options . ' ';
                 }
             }
-
         } else {
             $command .= ' ' . \escapeshellarg($input) . ' ';
         }
@@ -562,7 +560,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
     /**
      * Builds the options of the command string.
      *
-     * @param array        $options An array of options
+     * @param array $options An array of options
      *
      * @return string
      */
@@ -594,7 +592,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
                     if (\in_array($key, ['toc', 'cover'])) {
                         $optionString .= ' ' . $key . ' ' . \escapeshellarg($option);
                     } elseif (\in_array($key, ['image-dpi', 'image-quality'])) {
-                        $optionString .= ' --' . $key . ' ' . (int)$option;
+                        $optionString .= ' --' . $key . ' ' . (int) $option;
                     } else {
                         $optionString .= ' --' . $key . ' ' . \escapeshellarg($option);
                     }

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -538,7 +538,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
                             $options = $this->buildOptions($i['options']);
                         }
                     } else {
-                        throw new InvalidArgumentException(\sprintf('The url \'%s\' does not exist.', $name));
+                        throw new InvalidArgumentException("'url' is not defined.");
                     }
                 } else {
                     $url = $i;

--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -36,7 +36,7 @@ class Pdf extends AbstractGenerator
         $handledInput = $inputs;
         if (is_array($handledInput)) {
             foreach ($handledInput as $key => $input) {
-                if (is_array($input['options']) && !empty($input['options'])) {
+                if (!empty($input['options']) && is_array($input['options'])) {
                     $handledInput[$key]['options'] = $this->handleOptions($input['options']);
                 }
             }

--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -29,11 +29,20 @@ class Pdf extends AbstractGenerator
     /**
      * {@inheritdoc}
      */
-    public function generate($input, string $output, array $options = [], bool $overwrite = false): void
+    public function generate($inputs, string $output, array $options = [], bool $overwrite = false): void
     {
         $options = $this->handleOptions($this->mergeOptions($options));
 
-        parent::generate($input, $output, $options, $overwrite);
+        $handledInput = $inputs;
+        if (is_array($handledInput)) {
+            foreach ($handledInput as $key => $input) {
+                if (is_array($input['options']) && !empty($input['options'])) {
+                    $handledInput[$key]['options'] = $this->handleOptions($input['options']);
+                }
+            }
+        }
+
+        parent::generate($handledInput, $output, $options, $overwrite);
     }
 
     /**

--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -34,9 +34,9 @@ class Pdf extends AbstractGenerator
         $options = $this->handleOptions($this->mergeOptions($options));
 
         $handledInput = $inputs;
-        if (is_array($handledInput)) {
+        if (\is_array($handledInput)) {
             foreach ($handledInput as $key => $input) {
-                if (!empty($input['options']) && is_array($input['options'])) {
+                if (!empty($input['options']) && \is_array($input['options'])) {
                     $handledInput[$key]['options'] = $this->handleOptions($input['options']);
                 }
             }


### PR DESCRIPTION
Adds ability to support different header/footer per url and much more by accepting an item as an array. 'url' will be the html url while 'options' can be one of the options defined in wkhtmltopdf documentation.


```
$snapp->getOutput(array(
     array(
         'url' => 'https://www.github.com',
         'options' => array(
             'header-html' => 'header1.html'
         )
    ),
     array(
         'url' => 'https://www.php.net',
         'options' => array(
             'header-html' => 'header2.html'
         )
    )
));
```