### PR TITLE
rework command building

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -89,19 +89,6 @@ $pdf->generate(['https://google.com', 'https://google.jp'], '/tmp/out/test.pdf')
 $pdf->generateFromHtml(['<html><body>Doc 1</body></html>', '<html><body>Doc 2</body></html>'], '/tmp/out/test.pdf');
 ```
 
-###### *Q*: My chars with accents passed to wkhtmltopdf options are not correctly rendered, i.e. `footer-right => 'Página [page] de [toPage]'` is converted to 'PÃ¡gina 1 de 1'.
-
-*A*: The answer is long here. We use `escapeshellarg` function to escape all the option value passed to `wkhtmltox`. `escapeshellarg` makes its escape based on server locale, so if you are  experiencing this issue - you can set 
-```php
-setlocale(LC_CTYPE, 'es_ES.UTF-8')
-``` 
-
-or any locale which is suitable for you. You should take into account that if given locale is not configured on the server - you will still have an issue. Check your locales installed via running
-```bash
-locale -a
-```
-If the needed locale is missing on the server - you should install/configure it.
-
 ###### *Q*: How to put an header/footer on every page of the PDF?
 
 *A*: You need to provide either a valid file path or some HTML content. Note that your HTML document(s) needs to start with a valid doctype and have html, head and body tags, or wkhtmltopdf will fail to render the PDF properly.

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -578,7 +578,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
     /**
      * Executes the given process and returns the complete output as a string.
      *
-     * @param Process  $process
+     * @param Process $process
      *
      * @return array [status, stdout, stderr]
      */

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -197,7 +197,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
         ]);
 
         try {
-            list($status, $stdout, $stderr) = $this->runProcess($process, $command);
+            list($status, $stdout, $stderr) = $this->runProcess($process);
             $this->checkProcessStatus($status, $stdout, $stderr, $commandLine);
             $this->checkOutput($output, $commandLine);
         } catch (Exception $e) {
@@ -579,11 +579,10 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      * Executes the given process and returns the complete output as a string.
      *
      * @param Process  $process
-     * @param string[] $command Basically just for testing purposes.
      *
      * @return array [status, stdout, stderr]
      */
-    protected function runProcess(Process $process, array $command): array
+    protected function runProcess(Process $process): array
     {
         if (null !== $this->timeout) {
             $process->setTimeout($this->timeout);

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -197,7 +197,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
         ]);
 
         try {
-            list($status, $stdout, $stderr) = $this->runProcess($process);
+            list($status, $stdout, $stderr) = $this->runProcess($process, $command);
             $this->checkProcessStatus($status, $stdout, $stderr, $commandLine);
             $this->checkOutput($output, $commandLine);
         } catch (Exception $e) {
@@ -578,11 +578,12 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
     /**
      * Executes the given process and returns the complete output as a string.
      *
-     * @param Process $process
+     * @param Process  $process
+     * @param string[] $command Basically just for testing purposes.
      *
      * @return array [status, stdout, stderr]
      */
-    protected function runProcess(Process $process): array
+    protected function runProcess(Process $process, array $command): array
     {
         if (null !== $this->timeout) {
             $process->setTimeout($this->timeout);

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -598,25 +598,6 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
     }
 
     /**
-     * Executes the given command via shell and returns the complete output as
-     * a string.
-     *
-     * @param string $command
-     *
-     * @return array [status, stdout, stderr]
-     */
-    protected function executeCommand(string $command): array
-    {
-        if (\method_exists(Process::class, 'fromShellCommandline')) {
-            $process = Process::fromShellCommandline($command, null, $this->env);
-        } else {
-            $process = new Process($command, null, $this->env);
-        }
-
-        return $this->runProcess($process);
-    }
-
-    /**
      * Prepares the specified output.
      *
      * @param string $filename  The output filename

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -185,22 +185,24 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
         $this->prepareOutput($output, $overwrite);
 
         $command = $this->getCommand($input, $output, $options);
+        $process = new Process($command, null, $this->env);
+        $commandLine = $process->getCommandLine();
 
         $inputFiles = \is_array($input) ? \implode('", "', $input) : $input;
 
         $this->logger->info(\sprintf('Generate from file(s) "%s" to file "%s".', $inputFiles, $output), [
-            'command' => $command,
+            'command' => $commandLine,
             'env' => $this->env,
             'timeout' => $this->timeout,
         ]);
 
         try {
-            list($status, $stdout, $stderr) = $this->executeCommand($command);
-            $this->checkProcessStatus($status, $stdout, $stderr, $command);
-            $this->checkOutput($output, $command);
+            list($status, $stdout, $stderr) = $this->runProcess($process);
+            $this->checkProcessStatus($status, $stdout, $stderr, $commandLine);
+            $this->checkOutput($output, $commandLine);
         } catch (Exception $e) {
             $this->logger->error(\sprintf('An error happened while generating "%s".', $output), [
-                'command' => $command,
+                'command' => $commandLine,
                 'status' => $status ?? null,
                 'stdout' => $stdout ?? null,
                 'stderr' => $stderr ?? null,
@@ -210,7 +212,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
         }
 
         $this->logger->info(\sprintf('File "%s" has been successfully generated.', $output), [
-            'command' => $command,
+            'command' => $commandLine,
             'stdout' => $stdout,
             'stderr' => $stderr,
         ]);
@@ -292,9 +294,9 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      * @param array        $options An optional array of options that will be used
      *                              only for this command
      *
-     * @return string
+     * @return string[]
      */
-    public function getCommand($input, string $output, array $options = []): string
+    public function getCommand($input, string $output, array $options = []): array
     {
         if (null === $this->binary) {
             throw new LogicException('You must define a binary prior to conversion.');
@@ -496,50 +498,52 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
     }
 
     /**
-     * Builds the command string.
+     * Builds the command.
      *
      * @param string       $binary  The binary path/name
      * @param array|string $input   Url(s) or file location(s) of the page(s) to process
      * @param string       $output  File location to the image-to-be
      * @param array        $options An array of options
      *
-     * @return string
+     * @return string[]
      */
-    protected function buildCommand(string $binary, $input, string $output, array $options = []): string
+    protected function buildCommand(string $binary, $input, string $output, array $options = []): array
     {
-        $command = $binary;
-        $escapedBinary = \escapeshellarg($binary);
-        if (\is_executable($escapedBinary)) {
-            $command = $escapedBinary;
-        }
+        $command = [$binary];
 
         foreach ($options as $key => $option) {
             if (null !== $option && false !== $option) {
                 if (true === $option) {
                     // Dont't put '--' if option is 'toc'.
                     if ($key === 'toc') {
-                        $command .= ' ' . $key;
+                        $command[] = $key;
                     } else {
-                        $command .= ' --' . $key;
+                        $command[] = '--' . $key;
                     }
                 } elseif (\is_array($option)) {
                     if ($this->isAssociativeArray($option)) {
                         foreach ($option as $k => $v) {
-                            $command .= ' --' . $key . ' ' . \escapeshellarg($k) . ' ' . \escapeshellarg($v);
+                            $command[] = '--' . $key;
+                            $command[] = $k;
+                            $command[] = $v;
                         }
                     } else {
                         foreach ($option as $v) {
-                            $command .= ' --' . $key . ' ' . \escapeshellarg($v);
+                            $command[] = '--' . $key;
+                            $command[] = $v;
                         }
                     }
                 } else {
                     // Dont't add '--' if option is "cover"  or "toc".
-                    if (\in_array($key, ['toc', 'cover'])) {
-                        $command .= ' ' . $key . ' ' . \escapeshellarg($option);
-                    } elseif (\in_array($key, ['image-dpi', 'image-quality'])) {
-                        $command .= ' --' . $key . ' ' . (int) $option;
+                    if (\in_array($key, ['toc', 'cover'], true)) {
+                        $command[] = $key;
+                        $command[] = $option;
+                    } elseif (\in_array($key, ['image-dpi', 'image-quality'], true)) {
+                        $command[] = '--' . $key;
+                        $command[] = (int) $option;
                     } else {
-                        $command .= ' --' . $key . ' ' . \escapeshellarg($option);
+                        $command[] = '--' . $key;
+                        $command[] = $option;
                     }
                 }
             }
@@ -547,11 +551,12 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
 
         if (\is_array($input)) {
             foreach ($input as $i) {
-                $command .= ' ' . \escapeshellarg($i) . ' ';
+                $command[] = $i;
             }
-            $command .= \escapeshellarg($output);
+            $command[] = $output;
         } else {
-            $command .= ' ' . \escapeshellarg($input) . ' ' . \escapeshellarg($output);
+            $command[] = $input;
+            $command[] = $output;
         }
 
         return $command;
@@ -571,6 +576,28 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
     }
 
     /**
+     * Executes the given process and returns the complete output as a string.
+     *
+     * @param Process $process
+     *
+     * @return array [status, stdout, stderr]
+     */
+    protected function runProcess(Process $process): array
+    {
+        if (null !== $this->timeout) {
+            $process->setTimeout($this->timeout);
+        }
+
+        $process->run();
+
+        return [
+            $process->getExitCode(),
+            $process->getOutput(),
+            $process->getErrorOutput(),
+        ];
+    }
+
+    /**
      * Executes the given command via shell and returns the complete output as
      * a string.
      *
@@ -586,17 +613,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
             $process = new Process($command, null, $this->env);
         }
 
-        if (null !== $this->timeout) {
-            $process->setTimeout($this->timeout);
-        }
-
-        $process->run();
-
-        return [
-            $process->getExitCode(),
-            $process->getOutput(),
-            $process->getErrorOutput(),
-        ];
+        return $this->runProcess($process);
     }
 
     /**

--- a/tests/Knp/Snappy/AbstractGeneratorTest.php
+++ b/tests/Knp/Snappy/AbstractGeneratorTest.php
@@ -20,7 +20,12 @@ class AbstractGeneratorTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$commandPartDelimiter = '\\' !== \DIRECTORY_SEPARATOR ? "'" : ''; // command parts which are not quoted on Windows are enclosed by single quotes on Linux
+        /**
+         * Command parts which are not quoted on Windows are enclosed by single quotes on Linux.
+         * 
+         * We should find a better solution to handle this case. Help is appreciated.
+         */
+        self::$commandPartDelimiter = '\\' !== \DIRECTORY_SEPARATOR ? "'" : '';
     }
 
     public function testAddOption(): void

--- a/tests/Knp/Snappy/AbstractGeneratorTest.php
+++ b/tests/Knp/Snappy/AbstractGeneratorTest.php
@@ -20,9 +20,9 @@ class AbstractGeneratorTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        /**
+        /*
          * Command parts which are not quoted on Windows are enclosed by single quotes on Linux.
-         * 
+         *
          * We should find a better solution to handle this case. Help is appreciated.
          */
         self::$commandPartDelimiter = '\\' !== \DIRECTORY_SEPARATOR ? "'" : '';

--- a/tests/Knp/Snappy/AbstractGeneratorTest.php
+++ b/tests/Knp/Snappy/AbstractGeneratorTest.php
@@ -13,6 +13,16 @@ use ReflectionMethod;
 
 class AbstractGeneratorTest extends TestCase
 {
+    /**
+     * @var string
+     */
+    private static $commandPartDelimiter;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$commandPartDelimiter = '\\' !== \DIRECTORY_SEPARATOR ? "'" : ''; // command parts which are not quoted on Windows are enclosed by single quotes on Linux
+    }
+
     public function testAddOption(): void
     {
         $media = $this->getMockForAbstractClass(AbstractGenerator::class, [], '', false);
@@ -169,6 +179,8 @@ class AbstractGeneratorTest extends TestCase
 
     public function testGenerate(): void
     {
+        $d = self::$commandPartDelimiter;
+
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
                 'configure',
@@ -196,8 +208,8 @@ class AbstractGeneratorTest extends TestCase
                     'File "the_output_file" has been successfully generated.'
                 ),
                 $this->logicalOr(
-                    ['command' => 'the command', 'env' => null, 'timeout' => false],
-                    ['command' => 'the command', 'stdout' => 'stdout', 'stderr' => 'stderr']
+                    ['command' => "{$d}the{$d} {$d}command{$d}", 'env' => null, 'timeout' => false],
+                    ['command' => "{$d}the{$d} {$d}command{$d}", 'stdout' => 'stdout', 'stderr' => 'stderr']
                 )
             )
         ;
@@ -226,7 +238,7 @@ class AbstractGeneratorTest extends TestCase
         $media
             ->expects($this->once())
             ->method('checkProcessStatus')
-            ->with(0, 'stdout', 'stderr', 'the command')
+            ->with(0, 'stdout', 'stderr', "{$d}the{$d} {$d}command{$d}")
         ;
         $media
             ->expects($this->once())
@@ -242,6 +254,8 @@ class AbstractGeneratorTest extends TestCase
 
     public function testFailingGenerate(): void
     {
+        $d = self::$commandPartDelimiter;
+
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
                 'configure',
@@ -264,7 +278,7 @@ class AbstractGeneratorTest extends TestCase
             ->method('info')
             ->with(
                 $this->equalTo('Generate from file(s) "the_input_file" to file "the_output_file".'),
-                $this->equalTo(['command' => 'the command', 'env' => ['PATH' => '/usr/bin'], 'timeout' => 2000])
+                $this->equalTo(['command' => "{$d}the{$d} {$d}command{$d}", 'env' => ['PATH' => '/usr/bin'], 'timeout' => 2000])
             )
         ;
 
@@ -273,7 +287,7 @@ class AbstractGeneratorTest extends TestCase
             ->method('error')
             ->with(
                 $this->equalTo('An error happened while generating "the_output_file".'),
-                $this->equalTo(['command' => 'the command', 'status' => 1, 'stdout' => 'stdout', 'stderr' => 'stderr'])
+                $this->equalTo(['command' => "{$d}the{$d} {$d}command{$d}", 'status' => 1, 'stdout' => 'stdout', 'stderr' => 'stderr'])
             )
         ;
 
@@ -300,7 +314,7 @@ class AbstractGeneratorTest extends TestCase
         $media
             ->expects($this->once())
             ->method('checkProcessStatus')
-            ->with(1, 'stdout', 'stderr', 'the command')
+            ->with(1, 'stdout', 'stderr', "{$d}the{$d} {$d}command{$d}")
             ->willThrowException(new RuntimeException())
         ;
 

--- a/tests/Knp/Snappy/AbstractGeneratorTest.php
+++ b/tests/Knp/Snappy/AbstractGeneratorTest.php
@@ -245,7 +245,7 @@ class AbstractGeneratorTest extends TestCase
             ->method('checkOutput')
             ->with(
                 $this->equalTo('the_output_file'),
-                $this->equalTo('the command')
+                $this->equalTo("{$d}the{$d} {$d}command{$d}")
             )
         ;
 

--- a/tests/Knp/Snappy/PdfTest.php
+++ b/tests/Knp/Snappy/PdfTest.php
@@ -176,10 +176,15 @@ class PdfSpy extends Pdf
         return 'output';
     }
 
-    protected function runProcess(Process $process, array $command): array
+    public function getCommand($input, string $output, array $options = []): array
     {
-        $this->lastCommand = $command;
+        $this->lastCommand = parent::getCommand($input, $output, $options);
 
+        return $this->lastCommand;
+    }
+
+    protected function runProcess(Process $process): array
+    {
         return [0, 'output', 'errorOutput'];
     }
 


### PR DESCRIPTION
I noticed an issue on Windows with `escapeshellarg` messing with URL-encoded values when passing a URL for the `footer-html` option, so `"first%20last"` became `"first 20last"`. While trying to fix it I also noticed that the command is passed as a string to the `Process` which is deprecated.

So here's a rework of building the command so that its parts are passed as an array instead (which is the recommended way) and lets the Process component properly escape the arguments.

Let me know what you think.