### PR TITLE
Allow newer versions of the psr/log package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.1",
         "symfony/process": "~3.4||~4.3||~5.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0||^2.0||^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.4",


### PR DESCRIPTION
There isn't anything in this package that prohibits allowing the newer versions of the `psr/log` package as it is just a user of loggers and the `NullLogger` exists across all versions.