### PR TITLE
Fixed advertised compatible psr/log versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.1",
         "symfony/process": "~3.4||~4.3||~5.0",
-        "psr/log": "^1.0||^2.0||^3.0"
+        "psr/log": "^1.0||^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.4",


### PR DESCRIPTION
Partially fixes https://github.com/KnpLabs/snappy/issues/443 by not wrongly advertising which versions of psr/log are compatible. Working support for psr/log 3 should maybe be added later.