### PR TITLE
Upgrading PhpUnit config & Code Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ vendor
 bin
 .php_cs.cache
 .php-cs-fixer.cache
+.phpunit.result.cache
+.coverage/

--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ $snappy->setOption('xsl-style-sheet', 'http://path/to/stylesheet.xsl') //or loca
 $snappy->generateFromHtml('<p>Some content</p>', 'test.pdf');
 ```
 
+## PhpUnit Tests
+
+```bash
+$ vendor/bin/phpunit
+```
+
+## Code coverage
+Generates reports wth phpdbg and open it in firefox
+```bash
+$ phpdbg -qrr vendor/bin/phpunit
+$ firefox .coverage/index.html
+```
+
 ## Bugs & Support
 
 If you found a bug please fill a detailed issue with all the following points.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/log": "^1.0||^2.0||^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.4||~8.5",
+        "phpunit/phpunit": "~8.5",
         "phpstan/phpstan": "^0.12.7",
         "phpstan/phpstan-phpunit": "^0.12.6",
         "friendsofphp/php-cs-fixer": "^2.16||^3.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,4 +15,12 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-html" target="./.coverage" lowUpperBound="50" highLowerBound="90"/>
+    </logging>
 </phpunit>

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -190,7 +190,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
     /**
      * {@inheritdoc}
      */
-    public function generate($input, $output, array $options = [], $overwrite = false)
+    public function generate($input, string $output, array $options = [], $overwrite = false): void
     {
         $this->prepareOutput($output, $overwrite);
 
@@ -232,12 +232,12 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
     public function generateFromHtml($html, $output, array $options = [], $overwrite = false)
     {
         $fileNames = [];
-        if (\is_array($html)) {
-            foreach ($html as $htmlInput) {
-                $fileNames[] = $this->createTemporaryFile($htmlInput, 'html');
-            }
-        } else {
-            $fileNames[] = $this->createTemporaryFile($html, 'html');
+        if (is_string($html)) {
+            $html = [$html];
+        }
+        
+        foreach ($html as $htmlInput) {
+            $fileNames[] = $this->createTemporaryFile($htmlInput, 'html');
         }
 
         $this->generate($fileNames, $output, $options, $overwrite);
@@ -261,12 +261,12 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
     public function getOutputFromHtml($html, array $options = [])
     {
         $fileNames = [];
-        if (\is_array($html)) {
-            foreach ($html as $htmlInput) {
-                $fileNames[] = $this->createTemporaryFile($htmlInput, 'html');
-            }
-        } else {
-            $fileNames[] = $this->createTemporaryFile($html, 'html');
+        if (is_string($html)) {
+            $html = [$html];
+        }
+        
+        foreach ($html as $htmlInput) {
+            $fileNames[] = $this->createTemporaryFile($htmlInput, 'html');
         }
 
         return $this->getOutput($fileNames, $options);
@@ -362,7 +362,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      *
      * @return void
      */
-    public function resetOptions()
+    public function resetOptions(): void
     {
         $this->options = [];
         $this->configure();
@@ -634,7 +634,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      *
      * @return void
      */
-    protected function prepareOutput($filename, $overwrite)
+    protected function prepareOutput(string $filename, bool $overwrite)
     {
         $directory = \dirname($filename);
 
@@ -660,7 +660,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      *
      * @return string
      */
-    protected function getFileContents($filename)
+    protected function getFileContents(string $filename): string
     {
         $fileContent = \file_get_contents($filename);
 
@@ -678,7 +678,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      *
      * @return bool
      */
-    protected function fileExists($filename)
+    protected function fileExists(string $filename): bool
     {
         return \file_exists($filename);
     }

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -587,7 +587,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      *
      * @return bool
      */
-    protected function isAssociativeArray(array $array)
+    protected function isAssociativeArray(array $array): bool
     {
         return (bool) \count(\array_filter(\array_keys($array), 'is_string'));
     }
@@ -690,7 +690,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      *
      * @return bool
      */
-    protected function isFile($filename)
+    protected function isFile(string $filename): bool
     {
         return \strlen($filename) <= \PHP_MAXPATHLEN && \is_file($filename);
     }
@@ -702,7 +702,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      *
      * @return int
      */
-    protected function filesize($filename)
+    protected function filesize(string $filename): int
     {
         $filesize = \filesize($filename);
 

--- a/src/Knp/Snappy/GeneratorInterface.php
+++ b/src/Knp/Snappy/GeneratorInterface.php
@@ -20,7 +20,7 @@ interface GeneratorInterface
      *
      * @return void
      */
-    public function generate($input, $output, array $options = [], $overwrite = false);
+    public function generate($input, string $output, array $options = [], $overwrite = false): void;
 
     /**
      * Generates the output media file from the given HTML.

--- a/src/Knp/Snappy/Pdf.php
+++ b/src/Knp/Snappy/Pdf.php
@@ -29,7 +29,7 @@ class Pdf extends AbstractGenerator
     /**
      * {@inheritdoc}
      */
-    public function generate($input, $output, array $options = [], $overwrite = false)
+    public function generate($input, string $output, array $options = [], $overwrite = false): void
     {
         $options = $this->handleOptions($this->mergeOptions($options));
 

--- a/tests/Knp/Snappy/AbstractGeneratorTest.php
+++ b/tests/Knp/Snappy/AbstractGeneratorTest.php
@@ -778,11 +778,10 @@ class AbstractGeneratorTest extends TestCase
         $this->assertEquals($isAssociativeArray, $r->invokeArgs($generator, [$array]));
     }
 
-    /**
-     * @expectedException Knp\Snappy\Exception\FileAlreadyExistsException
-     */
     public function testItThrowsTheProperExceptionWhenFileExistsAndNotOverwritting(): void
     {
+        $this->expectException(\Knp\Snappy\Exception\FileAlreadyExistsException::class);
+        
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
                 'configure',


### PR DESCRIPTION
Since PhpUnit 7.4 is no longer supported, I've updated the composer config and in the process added the configuration for Code Coverage in PhpUnit.
* minor improvement (type-hinting)
* D.R.Y

:warning: Since GeneratorInterface signature has changed it probably will break KnpSnappyBundle (but it's OK since the version is fixed to 1.2 in the Symfony bundle)

Hope his helps