### PR TITLE
Remove suggestions from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,6 @@
         "friendsofphp/php-cs-fixer": "^2.16||^3.0",
         "pedrotroller/php-cs-custom-fixer": "^2.19"
     },
-    "suggest": {
-        "h4cc/wkhtmltopdf-amd64": "Provides wkhtmltopdf-amd64 binary for Linux-compatible machines, use version `~0.12` as dependency",
-        "h4cc/wkhtmltopdf-i386": "Provides wkhtmltopdf-i386 binary for Linux-compatible machines, use version `~0.12` as dependency",
-        "h4cc/wkhtmltoimage-amd64": "Provides wkhtmltoimage-amd64 binary for Linux-compatible machines, use version `~0.12` as dependency",
-        "h4cc/wkhtmltoimage-i386": "Provides wkhtmltoimage-i386 binary for Linux-compatible machines, use version `~0.12` as dependency",
-        "wemersonjanuario/wkhtmltopdf-windows": "Provides wkhtmltopdf executable for Windows, use version `~0.12` as dependency"
-    },
     "autoload": {
         "psr-4": {
             "Knp\\Snappy\\": "src/Knp/Snappy"


### PR DESCRIPTION
Now that wkhtmlhtmltopdf is archived these suggestions may be out of date.