### PR TITLE
chore: add ci tests for php 8.2, bump github actions versions (with phpstan fixed)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-20.04
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
             - name: Validate composer.json
@@ -19,7 +19,7 @@ jobs:
         name: PHP-CS-Fixer
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
@@ -32,9 +32,15 @@ jobs:
             fail-fast: false
             matrix:
                 include:
+                    - description: 'Symfony 6.3 DEV'
+                      php: '8.2'
+                      symfony: '6.3.*@dev'
+                    - description: 'Symfony 6.2'
+                      php: '8.2'
+                      symfony: '6.2.*'
                     - description: 'Symfony 6.0'
-                      php: '8.0'
-                      symfony: '6.0.*@dev'
+                      php: '8.1'
+                      symfony: '6.0.*'
                     - description: 'Symfony 5.0'
                       php: '7.3'
                       symfony: '5.0.*'
@@ -50,9 +56,9 @@ jobs:
         name: PHP ${{ matrix.php }} tests (${{ matrix.description }})
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: Cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.composer/cache/files
                   key: composer-${{ matrix.php }}-${{ matrix.symfony }}-${{ matrix.composer_option }}
@@ -68,7 +74,7 @@ jobs:
                   composer config prefer-stable true
               if: matrix.beta
             - name: remove cs-fixer for Symfony 6
-              if: contains(matrix.symfony, '6.0.*@dev')
+              if: contains(matrix.symfony, '6.3.*@dev')
               run: |
                   composer remove --dev friendsofphp/php-cs-fixer pedrotroller/php-cs-custom-fixer --no-update
             - run: composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_option }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ vendor
 bin
 .php_cs.cache
 .php-cs-fixer.cache
+.phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~7.4||~8.5",
-        "phpstan/phpstan": "^0.12.7",
-        "phpstan/phpstan-phpunit": "^0.12.6",
+        "phpstan/phpstan": "^1.0.0",
+        "phpstan/phpstan-phpunit": "^1.0.0",
         "friendsofphp/php-cs-fixer": "^2.16||^3.0",
         "pedrotroller/php-cs-custom-fixer": "^2.19"
     },

--- a/tests/Knp/Snappy/AbstractGeneratorTest.php
+++ b/tests/Knp/Snappy/AbstractGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Knp\Snappy;
 
 use Knp\Snappy\AbstractGenerator;
+use Knp\Snappy\Exception\FileAlreadyExistsException;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
@@ -40,6 +41,7 @@ class AbstractGeneratorTest extends TestCase
         try {
             $r->invokeArgs($media, ['baz', 'bat']);
             $this->fail($message);
+            // @phpstan-ignore-next-line
         } catch (InvalidArgumentException $e) {
             $this->anything();
         }
@@ -82,6 +84,7 @@ class AbstractGeneratorTest extends TestCase
         try {
             $r->invokeArgs($media, [['bak' => 'bam', 'bah' => 'bap', 'baz' => 'bat']]);
             $this->fail($message);
+            // @phpstan-ignore-next-line
         } catch (InvalidArgumentException $e) {
             $this->anything();
         }
@@ -542,6 +545,7 @@ class AbstractGeneratorTest extends TestCase
         try {
             $r->invokeArgs($media, [['foo' => 'ban', 'bad' => 'bah']]);
             $this->fail($message);
+            // @phpstan-ignore-next-line
         } catch (InvalidArgumentException $e) {
             $this->anything();
         }
@@ -778,11 +782,10 @@ class AbstractGeneratorTest extends TestCase
         $this->assertEquals($isAssociativeArray, $r->invokeArgs($generator, [$array]));
     }
 
-    /**
-     * @expectedException Knp\Snappy\Exception\FileAlreadyExistsException
-     */
     public function testItThrowsTheProperExceptionWhenFileExistsAndNotOverwritting(): void
     {
+        $this->expectException(FileAlreadyExistsException::class);
+
         $media = $this->getMockBuilder(AbstractGenerator::class)
             ->setMethods([
                 'configure',

--- a/tests/Knp/Snappy/PdfTest.php
+++ b/tests/Knp/Snappy/PdfTest.php
@@ -81,6 +81,7 @@ class PdfTest extends TestCase
         $this->assertEquals(1, \count($pdf->temporaryFiles));
         $this->expectException(Error::class);
         \trigger_error('test error', \E_USER_ERROR);
+        // @phpstan-ignore-next-line See https://github.com/phpstan/phpstan/issues/7799
         $this->assertFileNotExists(\reset($pdf->temporaryFiles));
     }
 


### PR DESCRIPTION
Replaces https://github.com/KnpLabs/snappy/pull/461.
Thanks to [Chris53897](https://github.com/Chris53897)!

I ignored phpstan errors (only on test files) reported by the new version of phpstan because they are rather phpstan bugs rather irrelevant errors as, those test files, will soon be completely rewritten.