### PR TITLE
feat: add bundle configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,19 +13,8 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
             - name: Validate composer.json
-              run: composer validate --strict --no-check-lock
-    cs-fixer:
-        runs-on: ubuntu-20.04
-        name: PHP-CS-Fixer
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '7.3'
-            - run: composer install --prefer-dist --no-interaction --no-progress --ansi
-            - run: vendor/bin/php-cs-fixer fix --diff --dry-run --verbose
+              run: |
+                (cd src/Bundle && composer validate --strict --no-check-lock)
     tests:
         runs-on: ubuntu-20.04
         strategy:
@@ -41,15 +30,9 @@ jobs:
                     - description: 'Symfony 6.0'
                       php: '8.1'
                       symfony: '6.0.*'
-                    - description: 'Symfony 5.0'
+                    - description: 'Symfony 5.4'
                       php: '7.3'
-                      symfony: '5.0.*'
-                    - description: 'Symfony 4.4'
-                      php: '7.1'
-                      symfony: '4.3.*@dev'
-                    - description: 'Symfony 3.4'
-                      php: '7.3'
-                      symfony: '3.4.*'
+                      symfony: '5.4.*'
                     - description: 'Beta deps'
                       php: '7.2'
                       beta: true
@@ -67,16 +50,58 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
             - run: |
-                  sed -ri 's/"symfony\/(.+)": "(.+)"/"symfony\/\1": "'${{ matrix.symfony }}'"/' composer.json;
+                  sed -ri 's/"symfony\/(.+)": "(.+)"/"symfony\/\1": "'${{ matrix.symfony }}'"/' src/Bundle/composer.json;
               if: matrix.symfony
             - run: |
                   composer config minimum-stability dev
                   composer config prefer-stable true
               if: matrix.beta
-            - name: remove cs-fixer for Symfony 6
-              if: contains(matrix.symfony, '6.3.*@dev')
-              run: |
-                  composer remove --dev friendsofphp/php-cs-fixer pedrotroller/php-cs-custom-fixer --no-update
-            - run: composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_option }}
-            - run: vendor/bin/phpunit
-            - run: vendor/bin/phpstan analyse --ansi --no-progress
+            - run: |
+                  (cd src/Bundle && composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_option }})
+            - run: |
+                  (cd src/Bundle && vendor/bin/phpunit)
+    tests-windows:
+        runs-on: windows-2022
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - description: 'Symfony 6.3 DEV'
+                      php: '8.2'
+                      symfony: '6.3.*@dev'
+                    - description: 'Symfony 6.2'
+                      php: '8.2'
+                      symfony: '6.2.*'
+                    - description: 'Symfony 6.0'
+                      php: '8.1'
+                      symfony: '6.0.*'
+                    - description: 'Symfony 5.4'
+                      php: '7.3'
+                      symfony: '5.4.*'
+                    - description: 'Beta deps'
+                      php: '7.2'
+                      beta: true
+        name: "[WINDOWS] PHP ${{ matrix.php }} tests (${{ matrix.description }})"
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Cache
+              uses: actions/cache@v3
+              with:
+                  path: ~/.composer/cache/files
+                  key: composer-${{ matrix.php }}-${{ matrix.symfony }}-${{ matrix.composer_option }}
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+            - run: |
+                  (Get-Content composer.json) -replace '("symfony/[^"]+": )"[^"]+"', '$1"${{ matrix.symfony }}"' | Out-File -encoding ASCII src/Bundle/composer.json
+              if: matrix.symfony
+            - run: |
+                  composer config minimum-stability dev
+                  composer config prefer-stable true
+              if: matrix.beta
+            - run: |
+                  {cd src/Bundle && composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_option }}}
+            - run: |
+                  {cd src/Bundle && vendor/bin/phpunit}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM composer:2.6.3 as composer
+
+###############################
+
+FROM php:8.2.10-fpm-alpine3.18
+
+WORKDIR /src
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+COPY ./entrypoint /usr/local/share/entrypoint
+COPY ./src /src
+
+ENTRYPOINT ["/usr/local/share/entrypoint"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+IMAGE_TAG:=knplabs/snappy:test
+
+.PHONY: build
+build:
+	docker build ./ -t "${IMAGE_TAG}"
+
+.PHONY: test
+test: build
+	$(MAKE) -C src/Bundle test IMAGE_TAG="${IMAGE_TAG}" ARGS="${ARGS}"

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -o pipefail
+set -o errexit
+
+(cd /src/Bundle && composer install)
+
+exec "${@}"

--- a/src/Bundle/.gitattributes
+++ b/src/Bundle/.gitattributes
@@ -1,3 +1,4 @@
-/spec/            export-ignore
+/Tests/           export-ignore
 /.gitattributes   export-ignore
 /.gitignore       export-ignore
+/phpunit.xml.dist export-ignore

--- a/src/Bundle/.gitignore
+++ b/src/Bundle/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
 /vendor
+.phpunit.result.cache

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KnpLabs\Snappy\Bundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+      $treeBuilder = new TreeBuilder('snappy');
+
+      $treeBuilder->getRootNode()
+        ->children()
+          ->arrayNode('backends')
+            ->useAttributeAsKey('name')
+            ->arrayPrototype()
+              ->children()
+                  ->scalarNode('driver')
+                    ->isRequired()
+                    ->validate()
+                        ->ifNotInArray(['wkhtmltopdf', 'chromium'])
+                        ->thenInvalid('Invalid backend driver %s')
+                    ->end()
+                  ->end()
+                  ->integerNode('timeout')
+                    ->min(1)
+                    ->defaultValue(30)
+                  ->end()
+                  ->scalarNode('binary_path')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                  ->end()
+                  ->arrayNode('options')
+                    ->useAttributeAsKey('name')
+                    ->scalarPrototype()->end()
+                  ->end()
+              ->end()
+            ->end()
+          ->end()
+        ->end()
+      ;
+
+      return $treeBuilder;
+    }
+}

--- a/src/Bundle/DependencyInjection/SnappyExtension.php
+++ b/src/Bundle/DependencyInjection/SnappyExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KnpLabs\Snappy\Bundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+class SnappyExtension extends Extension
+{
+  public function load(array $config, ContainerBuilder $container): void
+  {
+    foreach($config['backends'] as $backend) {
+      // @TODO: load backend services
+    }
+  }
+}

--- a/src/Bundle/Makefile
+++ b/src/Bundle/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test
+test:
+	docker run --rm -i -w /src/Bundle -v "$(shell pwd)/../:/src" "${IMAGE_TAG}" vendor/bin/phpunit $(ARGS) -v

--- a/src/Bundle/SnappyBundle.php
+++ b/src/Bundle/SnappyBundle.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KnpLabs\Snappy\Bundle;
 
-use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SnappyBundle extends AbstractBundle
+class SnappyBundle extends Bundle
 {
 
 }

--- a/src/Bundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Bundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\__Application__\Http\Cache\SharedCacheConfiguration;
+
+use KnpLabs\Snappy\Bundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+final class ConfigurationTest extends TestCase
+{
+  public function testItProcessesAMinimalWkhtmltopdfConfiguration(): void
+  {
+    $config = (new Processor())->processConfiguration(
+      new Configuration(),
+      [[
+        'backends' => [
+          'my_minimally_configured_wkhtmltopdf_backend' => [
+            'driver' => 'wkhtmltopdf',
+            'binary_path' => '/usr/bin/wkhtmltopdf',
+          ],
+        ],
+      ]]
+    );
+
+    $expected = [
+      'backends' => [
+        'my_minimally_configured_wkhtmltopdf_backend' => [
+          'driver' => 'wkhtmltopdf',
+          'timeout' => 30,
+          'binary_path' => '/usr/bin/wkhtmltopdf',
+          'options' => [],
+        ],
+      ],
+    ];
+
+    $this->assertEquals($config, $expected);
+  }
+
+  public function testItProcessesAFullWkhtmltopdfConfiguration(): void
+  {
+    $config = (new Processor())->processConfiguration(
+      new Configuration(),
+      [[
+        'backends' => [
+          'my_fully_configured_wkhtmltopdf_backend' => [
+            'driver' => 'wkhtmltopdf',
+            'timeout' => 60,
+            'binary_path' => '/usr/bin/wkhtmltopdf',
+            'options' => [
+                'key1' => 'val',
+                'key2' => null,
+                'key3',
+            ],
+          ],
+        ],
+      ]]
+    );
+
+    $expected = [
+      'backends' => [
+        'my_fully_configured_wkhtmltopdf_backend' => [
+          'driver' => 'wkhtmltopdf',
+          'timeout' => 60,
+          'binary_path' => '/usr/bin/wkhtmltopdf',
+          'options' => [
+              'key1' => 'val',
+              'key2' => null,
+              'key3',
+          ],
+        ],
+      ],
+    ];
+
+    $this->assertEquals($config, $expected);
+  }
+
+  public function testItProcessesAMinimalChromiumConfiguration(): void
+  {
+    $config = (new Processor())->processConfiguration(
+      new Configuration(),
+      [[
+        'backends' => [
+          'my_minimally_configured_chromium_backend' => [
+            'driver' => 'chromium',
+            'binary_path' => '/usr/bin/chromium',
+          ],
+        ],
+      ]]
+    );
+
+    $expected = [
+      'backends' => [
+        'my_minimally_configured_chromium_backend' => [
+          'driver' => 'chromium',
+          'timeout' => 30,
+          'binary_path' => '/usr/bin/chromium',
+          'options' => [],
+        ],
+      ],
+    ];
+
+    $this->assertEquals($config, $expected);
+  }
+
+  public function testItProcessesAFullChromiumConfiguration(): void
+  {
+    $config = (new Processor())->processConfiguration(
+      new Configuration(),
+      [[
+        'backends' => [
+          'my_fully_configured_chromium_backend' => [
+            'driver' => 'chromium',
+            'timeout' => 60,
+            'binary_path' => '/usr/bin/chromium',
+            'options' => [
+                'key1' => 'val',
+                'key2' => null,
+                'key3',
+            ],
+          ],
+        ],
+      ]]
+    );
+
+    $expected = [
+      'backends' => [
+        'my_fully_configured_chromium_backend' => [
+          'driver' => 'chromium',
+          'timeout' => 60,
+          'binary_path' => '/usr/bin/chromium',
+          'options' => [
+              'key1' => 'val',
+              'key2' => null,
+              'key3',
+          ],
+        ],
+      ],
+    ];
+
+    $this->assertEquals($config, $expected);
+  }
+
+  public function testItProcessesAMultiBackendConfiguration(): void
+  {
+    $config = (new Processor())->processConfiguration(
+      new Configuration(),
+      [[
+        'backends' => [
+          'my_minimally_configured_wkhtmltopdf_backend' => [
+            'driver' => 'wkhtmltopdf',
+            'binary_path' => '/usr/bin/wkhtmltopdf',
+          ],
+          'my_fully_configured_wkhtmltopdf_backend' => [
+            'driver' => 'wkhtmltopdf',
+            'timeout' => 60,
+            'binary_path' => '/usr/bin/wkhtmltopdf',
+            'options' => [
+              'key1' => 'val',
+              'key2' => null,
+              'key3',
+            ],
+          ],
+          'my_fully_configured_chromium_backend' => [
+            'driver' => 'chromium',
+            'timeout' => 60,
+            'binary_path' => '/usr/bin/chromium',
+            'options' => [
+              'key1' => 'val',
+              'key2' => null,
+              'key3',
+            ],
+          ],
+        ],
+      ]]
+    );
+
+    $expected = [
+      'backends' => [
+        'my_minimally_configured_wkhtmltopdf_backend' => [
+          'driver' => 'wkhtmltopdf',
+          'timeout' => 30,
+          'binary_path' => '/usr/bin/wkhtmltopdf',
+          'options' => [],
+        ],
+        'my_fully_configured_wkhtmltopdf_backend' => [
+          'driver' => 'wkhtmltopdf',
+          'timeout' => 60,
+          'binary_path' => '/usr/bin/wkhtmltopdf',
+          'options' => [
+            'key1' => 'val',
+            'key2' => null,
+            'key3',
+          ],
+        ],
+        'my_fully_configured_chromium_backend' => [
+          'driver' => 'chromium',
+          'timeout' => 60,
+          'binary_path' => '/usr/bin/chromium',
+          'options' => [
+            'key1' => 'val',
+            'key2' => null,
+            'key3',
+          ],
+        ],
+      ],
+    ];
+
+    $this->assertEquals($config, $expected);
+  }
+
+  public function testItThrowsWhenProcessingAnInvalidDriverConfiguration(): void
+  {
+    $this->expectException(InvalidConfigurationException::class);
+
+    (new Processor())->processConfiguration(
+      new Configuration(),
+      [[
+        'backends' => [
+          'invalid_backend' => [
+            'driver' => 'non-existing-driver',
+            'binary_path' => '/usr/bin/non-existing-binary',
+          ],
+        ],
+      ]]
+    );
+  }
+
+  public function testItThrowsWhenProcessingAnInvalidBinaryPathConfiguration(): void
+  {
+    $this->expectException(InvalidConfigurationException::class);
+
+    (new Processor())->processConfiguration(
+      new Configuration(),
+      [[
+        'backends' => [
+          'invalid_backend' => [
+            'driver' => 'wkhtmltopdf',
+          ],
+        ],
+      ]]
+    );
+  }
+
+  public function testItThrowsWhenProcessingAnInvalidTimeoutConfiguration(): void
+  {
+    $this->expectException(InvalidConfigurationException::class);
+
+    (new Processor())->processConfiguration(
+      new Configuration(),
+      [[
+        'backends' => [
+          'invalid_backend' => [
+            'driver' => 'wkhtmltopdf',
+            'timeout' => 0,
+            'binary_path' => '/usr/bin/wkhtmltopdf',
+          ],
+        ],
+      ]]
+    );
+  }
+}

--- a/src/Bundle/composer.json
+++ b/src/Bundle/composer.json
@@ -16,18 +16,23 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
-        "symfony/http-kernel": "^5.4|^6.2"
+        "php": ">=7.2.5",
+        "symfony/config": "^5.4|^6.0",
+        "symfony/dependency-injection": "^5.4|^6.0",
+        "symfony/http-kernel": "^5.4|^6.0"
     },
     "autoload": {
         "psr-4": { "KnpLabs\\Snappy\\Bundle\\": "" },
         "exclude-from-classmap": [
-            "/spec/"
+            "/Tests/"
         ]
     },
     "autoload-dev": {
         "psr-4": {
-            "KnpLabs\\Snappy\\Bundle\\Spec\\": "spec/"
+            "Tests\\KnpLabs\\Snappy\\Bundle\\": "Tests/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "<7.5|^9.6"
     }
 }

--- a/src/Bundle/phpunit.xml.dist
+++ b/src/Bundle/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+  backupGlobals="false"
+  colors="true"
+  bootstrap="vendor/autoload.php"
+  failOnRisky="true"
+  failOnWarning="true"
+>
+  <php>
+    <ini name="error_reporting" value="-1" />
+  </php>
+
+  <testsuites>
+    <testsuite name="KNPLabs Snappy Bundle Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
+
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+</phpunit>


### PR DESCRIPTION
This PR includes the bundle configuration parser and bootstraps the extension that will automatically create services based on the provided configuration.

The configuration allows to configure one or multiple backends with the following parameters:
```yaml
snappy:
  backends:
    my_first_backend:
      driver: wkhtmltopdf
      binary_path: /usr/bin/wkhtmltopdf
      timeout: 30
      options:
        my_option_1: my_value_1
        my_option_2: my_value_2
    my_second_backend:
      driver: chromium
      binary_path: /usr/bin/chromium
```
The above configuration will expose two services named `snappy.my_first_backend` and `snappy.my_second_backend` plus (potentially) all their variations for inputs and outputs.

The available parameters are the following:
- driver: the backend to use, for the moment the supported options are `wkhtmltopdf` and `chromium`
- binary_path: the backend binary path
- timeout: the timeout in seconds
- options: a key/value pair of options

Users will also be able to configure multiple backends of the same type, with different configurations.

In case we will like to support other backends that are not binary based we will add another configuration type more suited to them.

Does that work for you?

Note: in this PR I also fixed the CI workflow.
