### PR TITLE
Add support symfony 7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '7.3'
+                  php-version: '8.1'
             - run: composer install --prefer-dist --no-interaction --no-progress --ansi
             - run: vendor/bin/php-cs-fixer fix --diff --dry-run --verbose
     tests:
@@ -32,29 +32,26 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - description: 'Symfony 6.4 DEV'
+                    - description: 'Symfony 7.1 DEV'
                       php: '8.2'
-                      symfony: '6.4.*@dev'
-                    - description: 'Symfony 6.3'
+                      symfony: '7.1.*@dev'
+                    - description: 'Symfony 7.0'
                       php: '8.3'
-                      symfony: '6.3.*'
-                    - description: 'Symfony 6.3'
-                      php: '8.2'
-                      symfony: '6.3.*'
-                    - description: 'Symfony 6.0'
+                      symfony: '7.0.*'
+                    - description: 'Symfony 6.4'
                       php: '8.1'
+                      symfony: '6.4.*'
+                    - description: 'Symfony 6.0'
+                      php: '8.3'
                       symfony: '6.0.*'
+                    - description: 'Symfony 5.4'
+                      php: '8.1'
+                      symfony: '5.4.*'
                     - description: 'Symfony 5.0'
-                      php: '7.3'
+                      php: '8.3'
                       symfony: '5.0.*'
-                    - description: 'Symfony 4.4'
-                      php: '7.1'
-                      symfony: '4.3.*@dev'
-                    - description: 'Symfony 3.4'
-                      php: '7.3'
-                      symfony: '3.4.*'
                     - description: 'Beta deps'
-                      php: '7.2'
+                      php: '8.1'
                       beta: true
         name: PHP ${{ matrix.php }} tests (${{ matrix.description }})
         steps:
@@ -76,8 +73,8 @@ jobs:
                   composer config minimum-stability dev
                   composer config prefer-stable true
               if: matrix.beta
-            - name: remove cs-fixer for Symfony 6
-              if: contains(matrix.symfony, '6.4.*@dev')
+            - name: remove cs-fixer for Symfony 7 (temporary as not-supported yet)
+              if: contains(matrix.symfony, '7.1.*@dev') || contains(matrix.symfony, '7.0.*')
               run: |
                   composer remove --dev friendsofphp/php-cs-fixer pedrotroller/php-cs-custom-fixer --no-update
             - run: composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_option }}
@@ -89,15 +86,18 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - description: 'Symfony 6.4 DEV'
+                    - description: 'Symfony 7.1 DEV'
                       php: '8.2'
-                      symfony: '6.4.*@dev'
-                    - description: 'Symfony 6.3'
+                      symfony: '7.1.*@dev'
+                    - description: 'Symfony 7.0'
                       php: '8.3'
-                      symfony: '6.3.*'
-                    - description: 'Symfony 6.3'
-                      php: '8.2'
-                      symfony: '6.3.*'
+                      symfony: '7.0.*'
+                    - description: 'Symfony 6.4'
+                      php: '8.1'
+                      symfony: '6.4.*'
+                    - description: 'Symfony 5.4'
+                      php: '8.1'
+                      symfony: '5.4.*'
         name: "[WINDOWS] PHP ${{ matrix.php }} tests (${{ matrix.description }})"
         steps:
             - name: Checkout
@@ -118,8 +118,8 @@ jobs:
                   composer config minimum-stability dev
                   composer config prefer-stable true
               if: matrix.beta
-            - name: remove cs-fixer for Symfony 6
-              if: contains(matrix.symfony, '6.4.*@dev')
+            - name: remove cs-fixer for Symfony 7 (temporary as not-supported yet)
+              if: contains(matrix.symfony, '7.1.*@dev') || contains(matrix.symfony, '7.0.*')
               run: |
                   composer remove --dev friendsofphp/php-cs-fixer pedrotroller/php-cs-custom-fixer --no-update
             - run: composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_option }}

--- a/composer.json
+++ b/composer.json
@@ -16,23 +16,16 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "symfony/process": "~3.4||~4.3||~5.0||~6.0",
-        "psr/log": "^1.0||^2.0||^3.0"
+        "php": ">=8.1",
+        "symfony/process": "^5.0||^6.0||^7.0",
+        "psr/log": "^2.0||^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.4||~8.5",
+        "phpunit/phpunit": "^8.5",
         "phpstan/phpstan": "^1.0.0",
         "phpstan/phpstan-phpunit": "^1.0.0",
-        "friendsofphp/php-cs-fixer": "^2.16||^3.0",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "pedrotroller/php-cs-custom-fixer": "^2.19"
-    },
-    "suggest": {
-        "h4cc/wkhtmltopdf-amd64": "Provides wkhtmltopdf-amd64 binary for Linux-compatible machines, use version `~0.12` as dependency",
-        "h4cc/wkhtmltopdf-i386": "Provides wkhtmltopdf-i386 binary for Linux-compatible machines, use version `~0.12` as dependency",
-        "h4cc/wkhtmltoimage-amd64": "Provides wkhtmltoimage-amd64 binary for Linux-compatible machines, use version `~0.12` as dependency",
-        "h4cc/wkhtmltoimage-i386": "Provides wkhtmltoimage-i386 binary for Linux-compatible machines, use version `~0.12` as dependency",
-        "wemersonjanuario/wkhtmltopdf-windows": "Provides wkhtmltopdf executable for Windows, use version `~0.12` as dependency"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Adds:
- support for symfony/symfony 7.x

Removes:
- support for PHP 7.x
- support for symfony/symfony version 3.x and 4.x
- support for psr/log 1 