### PR TITLE
Overwrite timeout of jobs default of 60 seconds to null if null

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -601,9 +601,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
             $process = new Process($command, null, $this->env);
         }
 
-        if (null !== $this->timeout) {
-            $process->setTimeout($this->timeout);
-        }
+        $process->setTimeout($this->timeout);
 
         $process->run();
 


### PR DESCRIPTION
Hi there.

There is a bug when using the AbstractGenerator where timeout of null does not mean no timeout.

This is due to the constructor and fromShellCommandline method of `Symfony\Component\Process\Process` having the default parameter timeout of 60 seconds, and the deleted if condition causing it to not be overwritten if the timeout of the AbstractGenerator is null.

I see no problem in removing this if statement, as passing null to setTimeout will simply set the timeout to null in the Symfony process, and it fixes the issue.