### PR TITLE
ci: fix ci --no-security-blocking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,11 +79,7 @@ jobs:
                   composer config minimum-stability dev
                   composer config prefer-stable true
               if: matrix.beta
-            - name: remove cs-fixer for Symfony 7 (temporary as not-supported yet)
-              if: contains(matrix.symfony, '7.2.*@dev') || contains(matrix.symfony, '7.0.*')
-              run: |
-                  composer remove --dev friendsofphp/php-cs-fixer pedrotroller/php-cs-custom-fixer --no-update
-            - run: composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_option }}
+            - run: composer update --prefer-dist --no-interaction --no-progress --no-security-blocking --ansi ${{ matrix.composer_option }}
             - run: vendor/bin/phpunit
             - run: vendor/bin/phpstan analyse --ansi --no-progress
     tests-windows:
@@ -129,11 +125,6 @@ jobs:
             - run: |
                   composer config minimum-stability dev
                   composer config prefer-stable true
-              if: matrix.beta
-            - name: remove cs-fixer for Symfony 7 (temporary as not-supported yet)
-              if: contains(matrix.symfony, '7.2.*@dev') || contains(matrix.symfony, '7.0.*')
-              run: |
-                  composer remove --dev friendsofphp/php-cs-fixer pedrotroller/php-cs-custom-fixer --no-update
-            - run: composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_option }}
+            - run: composer update --prefer-dist --no-interaction --no-progress --no-security-blocking --ansi ${{ matrix.composer_option }}
             - run: vendor/bin/phpunit
             - run: vendor/bin/phpstan analyse --ansi --no-progress


### PR DESCRIPTION
friendsofphp/php-cs-fixer does support now higher Symfony versions.
That is the reason i removed this block.

The new arguments allows to install unsupported symfony version with security errors. composer => 2.9.0
https://github.com/composer/composer/issues/12612