### PR TITLE
Fix: reset temporaryFiles array in finally block

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -317,8 +317,12 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      */
     public function removeTemporaryFiles()
     {
-        foreach ($this->temporaryFiles as $file) {
-            $this->unlink($file);
+        try {
+            foreach ($this->temporaryFiles as $file) {
+                $this->unlink($file);
+            }
+        } finally {
+            $this->temporaryFiles = [];
         }
     }
 

--- a/tests/Knp/Snappy/AbstractGeneratorTest.php
+++ b/tests/Knp/Snappy/AbstractGeneratorTest.php
@@ -861,6 +861,8 @@ class AbstractGeneratorTest extends TestCase
 
         $remove = new ReflectionMethod($generator, 'removeTemporaryFiles');
         $remove->invoke($generator);
+
+        $this->assertCount(0, $files->getValue($generator));
     }
 
     public function testleanupTemporaryFiles(): void
@@ -887,6 +889,8 @@ class AbstractGeneratorTest extends TestCase
 
         $remove = new ReflectionMethod($generator, 'removeTemporaryFiles');
         $remove->invoke($generator);
+
+        $this->assertCount(0, $files->getValue($generator));
     }
 
     public function testResetOptions(): void


### PR DESCRIPTION
## Summary
- Use a finally block in `removeTemporaryFiles()` to ensure `$this->temporaryFiles` is always cleared after removal
- Prevents attempting to delete the same files multiple times when the method is called from both the shutdown function and destructor
- Added test assertions to verify the array is cleared after calling `removeTemporaryFiles()`

## Test plan
- [x] Existing tests pass
- [x] Added assertions to verify `temporaryFiles` array is emptied after removal