### PR TITLE
Fix: [V2] Fix container compilation issue

### DIFF
--- a/src/Framework/Symfony/DependencyInjection/Configuration/DompdfConfigurationFactory.php
+++ b/src/Framework/Symfony/DependencyInjection/Configuration/DompdfConfigurationFactory.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 final class DompdfConfigurationFactory implements BackendConfigurationFactory
 {
@@ -38,7 +39,7 @@ final class DompdfConfigurationFactory implements BackendConfigurationFactory
                 new Definition(
                     DompdfFactory::class,
                     [
-                        '$streamFactory' => $container->getDefinition(StreamFactoryInterface::class),
+                        '$streamFactory' => new Reference(StreamFactoryInterface::class),
                     ]
                 ),
             )

--- a/src/Framework/Symfony/DependencyInjection/Configuration/WkHtmlToPdfConfigurationFactory.php
+++ b/src/Framework/Symfony/DependencyInjection/Configuration/WkHtmlToPdfConfigurationFactory.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 final class WkHtmlToPdfConfigurationFactory implements BackendConfigurationFactory
 {
@@ -37,7 +38,7 @@ final class WkHtmlToPdfConfigurationFactory implements BackendConfigurationFacto
                 new Definition(
                     WkHtmlToPdfFactory::class,
                     [
-                        '$streamFactory' => $container->getDefinition(StreamFactoryInterface::class),
+                        '$streamFactory' => new Reference(StreamFactoryInterface::class),
                         '$binary' => $configuration['binary'],
                         '$timeout' => $configuration['timeout'],
                     ]


### PR DESCRIPTION
Using Symfony 7.4, I could not build a container with snappy enabled:

```
bin/console debug:container

In ContainerBuilder.php line 1048:
                                                                                        
  You have requested a non-existent service "Psr\Http\Message\StreamFactoryInterface".  
```

This PR attempts to fix that issue