### PR TITLE
track temp file even if content is null

### DIFF
--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -512,6 +512,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
             \file_put_contents($filename, $content);
         }
 
+        // track temp file even if we don't write to it, the method calling this creation may write to it
         $this->temporaryFiles[] = $filename;
 
         return $filename;

--- a/src/Knp/Snappy/AbstractGenerator.php
+++ b/src/Knp/Snappy/AbstractGenerator.php
@@ -510,8 +510,9 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
 
         if (null !== $content) {
             \file_put_contents($filename, $content);
-            $this->temporaryFiles[] = $filename;
         }
+
+        $this->temporaryFiles[] = $filename;
 
         return $filename;
     }

--- a/tests/Knp/Snappy/AbstractGeneratorTest.php
+++ b/tests/Knp/Snappy/AbstractGeneratorTest.php
@@ -888,7 +888,7 @@ class AbstractGeneratorTest extends TestCase
         $create->invoke($generator, null, null);
 
         $files = new ReflectionProperty($generator, 'temporaryFiles');
-        $this->assertCount(0, $files->getValue($generator));
+        $this->assertCount(1, $files->getValue($generator));
 
         $remove = new ReflectionMethod($generator, 'removeTemporaryFiles');
         $remove->invoke($generator);


### PR DESCRIPTION
I've noticed temp files piling up. This is because when [getOutput](https://github.com/KnpLabs/snappy/blob/133a2c4ec5c0882d8a23cd468fbbfda657ce90ac/src/Knp/Snappy/AbstractGenerator.php#L242) is called, the content is null.

Get output writes to the file during generate but this means the temp file is never tracked or cleaned up.